### PR TITLE
Expose publicly the Handlebars Configuration

### DIFF
--- a/source/Handlebars/Handlebars.cs
+++ b/source/Handlebars/Handlebars.cs
@@ -40,6 +40,13 @@ namespace Handlebars
         {
             _singleton.RegisterHelper(helperName, helperFunction);
         }
+
+        /// <summary>
+        /// Expose the configuration on order to have access in all Helpers and Templates.
+        /// </summary>
+        public static HandlebarsConfiguration Configuration
+        {
+            get { return _singleton.Configuration; }
+        }
     }
 }
-


### PR DESCRIPTION
Expose the Handlebars Configuration class in order to give the ability to access the registered Helpers and Templates. This is related to issue #26 