### PR TITLE
Allow indexing into arrays with paths.

### DIFF
--- a/source/Handlebars.Test/BasicIntegrationTests.cs
+++ b/source/Handlebars.Test/BasicIntegrationTests.cs
@@ -34,6 +34,45 @@ namespace Handlebars.Test
         }
 
         [Test]
+        public void BasicPathArray()
+        {
+            var source = "Hello, {{ names.[1] }}!";
+            var template = Handlebars.Compile(source);
+            var data = new
+            {
+                names = new[] {"Foo", "Handlebars.Net"}
+            };
+            var result = template(data);
+            Assert.AreEqual("Hello, Handlebars.Net!", result);
+        }
+
+        [Test]
+        public void BasicPathArrayChildPath()
+        {
+            var source = "Hello, {{ names.[1].name }}!";
+            var template = Handlebars.Compile(source);
+            var data = new
+            {
+                names = new[] {new {name = "Foo"}, new {name = "Handlebars.Net"}}
+            };
+            var result = template(data);
+            Assert.AreEqual("Hello, Handlebars.Net!", result);
+        }
+
+        [Test]
+        public void BasicPathArrayNoSquareBracketsChildPath()
+        {
+            var source = "Hello, {{ names.1.name }}!";
+            var template = Handlebars.Compile(source);
+            var data = new
+            {
+                names = new[] { new { name = "Foo" }, new { name = "Handlebars.Net" } }
+            };
+            var result = template(data);
+            Assert.AreEqual("Hello, Handlebars.Net!", result);
+        }
+
+        [Test]
         public void BasicIfElse()
         {
             var source = "Hello, {{#if basic_bool}}Bob{{else}}Sam{{/if}}!";

--- a/source/Handlebars/Compiler/Translation/Expression/PathBinder.cs
+++ b/source/Handlebars/Compiler/Translation/Expression/PathBinder.cs
@@ -137,13 +137,20 @@ namespace Handlebars.Compiler
                 }
                 return contextValue;
             }
+            else
+            {
+                return AccessMember(instance, segment);
+            }
+        }
 
+        private object AccessMember(object instance, string memberName)
+        {
             var enumerable = instance as IEnumerable<object>;
             if (enumerable != null)
             {
                 var index = 0;
                 var indexRegex = new Regex(@"^\[?(\d+)\]?$");
-                var match = indexRegex.Match(segment);
+                var match = indexRegex.Match(memberName);
                 if (!match.Success || match.Groups.Count < 2 || !int.TryParse(match.Groups[1].Value, out index))
                 {
                     throw new HandlebarsRuntimeException("Invalid array index in path.");
@@ -151,11 +158,6 @@ namespace Handlebars.Compiler
                 return enumerable.ElementAt(index);
             }
 
-            return AccessMember(instance, segment);
-        }
-
-        private object AccessMember(object instance, string memberName)
-        {
             var resolvedMemberName = this.ResolveMemberName(memberName);
             //crude handling for dynamic objects that don't have metadata
             if (typeof(IDynamicMetaObjectProvider).IsAssignableFrom(instance.GetType()))


### PR DESCRIPTION
This fixes issue #33.

This is slightly more flexible than handlebarjs is. Handlebarsjs supports indexes with and without square brackets when a child path is present, but evidently requires the square brackets when there is no child path. See http://stackoverflow.com/questions/8044219/handlebars-access-array-item

I did not immediately see how to easily replicate the exact behavior of handlebarsjs, and it was very easy to support missing square brackets in both cases. So I simply did not include a unit test to test the case that handlebarsjs does not support.