### PR TITLE
Reserve dynamic iteration logic for non-list IDynamicMetaObjectProviders

### DIFF
--- a/source/Handlebars.Test/DynamicTests.cs
+++ b/source/Handlebars.Test/DynamicTests.cs
@@ -64,6 +64,18 @@ namespace HandlebarsDotNet.Test
 			Assert.AreEqual("test1", output);
 		}
 
+        [Test]
+        public void JsonTestArrays(){
+            var model = Newtonsoft.Json.JsonConvert.DeserializeObject<dynamic>("[{\"Key\": \"Key1\", \"Value\": \"Val1\"},{\"Key\": \"Key2\", \"Value\": \"Val2\"}]");
+
+            var source = "{{#each this}}{{Key}}{{Value}}{{/each}}";
+
+            var template = Handlebars.Compile(source);
+
+            var output = template(model);
+
+            Assert.AreEqual("Key1Val1Key2Val2", output);
+        }
         private class MyDynamicModel : DynamicObject
         {
             private Dictionary<string, object> properties = new Dictionary<string, object>

--- a/source/Handlebars/Compiler/Translation/Expression/IteratorBinder.cs
+++ b/source/Handlebars/Compiler/Translation/Expression/IteratorBinder.cs
@@ -55,7 +55,7 @@ namespace HandlebarsDotNet.Compiler
                 Expression.IfThenElse(
                     Expression.TypeIs(iex.Sequence, typeof(IEnumerable)),
                     Expression.IfThenElse(
-                        Expression.TypeIs(iex.Sequence, typeof(IDynamicMetaObjectProvider)),
+                        Expression.Call(new Func<object, bool>(IsNonListDynamic).Method, new [] {iex.Sequence}),
                         GetDynamicIterator(iteratorBindingContext, iex),
                         Expression.IfThenElse(
                             Expression.Call(new Func<object, bool>(IsGenericDictionary).Method, new[] {iex.Sequence}),
@@ -139,6 +139,11 @@ namespace HandlebarsDotNet.Compiler
                         fb.Compile(new [] { iex.Template }, contextParameter),
                         fb.Compile(new [] { iex.IfEmpty }, CompilationContext.BindingContext) 
                     }));
+        }
+
+        private static bool IsNonListDynamic(object target){
+            var interfaces = target.GetType().GetInterfaces();
+            return interfaces.Contains(typeof (IDynamicMetaObjectProvider)) && !interfaces.Contains(typeof(IList));
         }
 
         private static bool IsGenericDictionary(object target)


### PR DESCRIPTION
Some objects implement both IEnumerable and IDynamicMetaObjectProviders, but do
not have dynamic member names (chief example being Newtonsoft.Json JArrays).
This patch ensures that Handlebars.Net only uses dynamic iteration logic on
dynamic objects that cannot be iterated over in a more appropriate manner.