### PR TITLE
Exception includes name of partial

### DIFF
--- a/source/Handlebars/Compiler/Lexer/Converter/PartialConverter.cs
+++ b/source/Handlebars/Compiler/Lexer/Converter/PartialConverter.cs
@@ -1,7 +1,6 @@
-﻿using System;
-using System.Linq.Expressions;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using HandlebarsDotNet.Compiler.Lexer;
 
 namespace HandlebarsDotNet.Compiler
@@ -23,9 +22,9 @@ namespace HandlebarsDotNet.Compiler
             while (enumerator.MoveNext())
             {
                 var item = enumerator.Current;
-                if (item is PartialToken)
+                var partialToken = item as PartialToken;
+                if (partialToken != null)
                 {
-                    var partialToken = item as PartialToken;
                     var partialName = partialToken.Value.Substring(1);
                     var arguments = AccumulateArguments(enumerator);
                     if (arguments.Count == 0)
@@ -38,7 +37,7 @@ namespace HandlebarsDotNet.Compiler
                     }
                     else
                     {
-                        throw new HandlebarsCompilerException("Partial can only accept 0 or 1 arguments");
+                        throw new HandlebarsCompilerException(string.Format("Partial {0} can only accept 0 or 1 arguments", partialName));
                     }
                     yield return enumerator.Current;
                 }

--- a/source/Handlebars/Compiler/Translation/Expression/PartialBinder.cs
+++ b/source/Handlebars/Compiler/Translation/Expression/PartialBinder.cs
@@ -51,7 +51,7 @@ namespace HandlebarsDotNet.Compiler
         {
             if (configuration.RegisteredTemplates.ContainsKey(partialName) == false)
             {
-                throw new HandlebarsRuntimeException("Referenced partial name could not be resolved");
+                throw new HandlebarsRuntimeException(string.Format("Referenced partial name {0} could not be resolved", partialName));
             }
             configuration.RegisteredTemplates[partialName](context.TextWriter, context);
         }


### PR DESCRIPTION
+ Exception includes now name of partial
+ Use `as` instead of `is` and then `as`

I added a few changes which makes finding the problem as a user of the library a bit simpler plus a small "optimization"