### PR TITLE
Correction Iterating Non Enumarators that not implements IList

### DIFF
--- a/source/Handlebars.Test/DynamicTests.cs
+++ b/source/Handlebars.Test/DynamicTests.cs
@@ -76,6 +76,21 @@ namespace HandlebarsDotNet.Test
 
             Assert.AreEqual("Key1Val1Key2Val2", output);
         }
+        [Test]
+        public void SystemJsonTestArrays()
+        {
+            var model = System.Web.Helpers.Json.Decode("[{\"Key\": \"Key1\", \"Value\": \"Val1\"},{\"Key\": \"Key2\", \"Value\": \"Val2\"}]");
+
+            var source = "{{#each this}}{{Key}}{{Value}}{{/each}}";
+
+            var template = Handlebars.Compile(source);
+
+            var output = template(model);
+
+            Assert.AreEqual("Key1Val1Key2Val2", output);
+        }
+
+
         private class MyDynamicModel : DynamicObject
         {
             private Dictionary<string, object> properties = new Dictionary<string, object>

--- a/source/Handlebars.Test/Handlebars.Test.csproj
+++ b/source/Handlebars.Test/Handlebars.Test.csproj
@@ -33,6 +33,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="nunit.framework">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
@@ -40,7 +44,26 @@
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="System.Web.Helpers, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
+    <Reference Include="System.Web.Helpers, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.2.0.30506.0\lib\net40\System.Web.Helpers.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.AspNet.Razor.2.0.20710.0\lib\net40\System.Web.Razor.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.WebPages, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.2.0.30506.0\lib\net40\System.Web.WebPages.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.WebPages.Deployment, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.2.0.30506.0\lib\net40\System.Web.WebPages.Deployment.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.WebPages.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.2.0.30506.0\lib\net40\System.Web.WebPages.Razor.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BasicIntegrationTests.cs" />

--- a/source/Handlebars.Test/Handlebars.Test.csproj
+++ b/source/Handlebars.Test/Handlebars.Test.csproj
@@ -40,6 +40,7 @@
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="System.Web.Helpers, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BasicIntegrationTests.cs" />

--- a/source/Handlebars.Test/packages.config
+++ b/source/Handlebars.Test/packages.config
@@ -1,5 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.AspNet.Razor" version="2.0.20710.0" targetFramework="net40" />
+  <package id="Microsoft.AspNet.WebPages" version="2.0.30506.0" targetFramework="net40" />
+  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net40" />
   <package id="NUnit" version="2.6.4" targetFramework="net40" />
 </packages>

--- a/source/Handlebars/Compiler/Translation/Expression/IteratorBinder.cs
+++ b/source/Handlebars/Compiler/Translation/Expression/IteratorBinder.cs
@@ -143,7 +143,8 @@ namespace HandlebarsDotNet.Compiler
 
         private static bool IsNonListDynamic(object target){
             var interfaces = target.GetType().GetInterfaces();
-            return interfaces.Contains(typeof (IDynamicMetaObjectProvider)) && !interfaces.Contains(typeof(IList));
+            return interfaces.Contains(typeof (IDynamicMetaObjectProvider)) 
+                && ((IDynamicMetaObjectProvider)target).GetMetaObject(Expression.Constant(target)).GetDynamicMemberNames().Any();
         }
 
         private static bool IsGenericDictionary(object target)


### PR DESCRIPTION
Some objects implement both IEnumerable and IDynamicMetaObjectProviders, but do
not have dynamic member names (chief example being Newtonsoft.Json JArrays and also System.Web.Helpers.DynamicJsonArray).

But System.Web.Helpers.DynamicJsonArray dont implement IList.

Now : check the presence of DynamicMemberNames in place of IList.

Correction of issue generated by 
https://github.com/rexm/Handlebars.Net/commit/787e6c334ced09b54d6cbd6a12ca101995b5305f