### PR TITLE
Add support for backslash escaping templates from evaluation

### DIFF
--- a/source/Handlebars.Test/BasicIntegrationTests.cs
+++ b/source/Handlebars.Test/BasicIntegrationTests.cs
@@ -496,6 +496,22 @@ namespace HandlebarsDotNet.Test
 		}
 
         [Test]
+        public void BasicEscape()
+        {
+            string source = @"Hello, \{{raw_value}}!";
+
+            var template = Handlebars.Compile(source);
+
+            var data = new
+            {
+                raw_value = "<div>I shouldn't display</div>"
+            };
+
+            var result = template(data);
+            Assert.AreEqual(@"Hello, {{raw_value}}!", result);
+        }
+
+        [Test]
         public void BasicNumberLiteral()
         {
             string source = "{{eval 2  3}}";

--- a/source/Handlebars/Compiler/Lexer/Tokenizer.cs
+++ b/source/Handlebars/Compiler/Lexer/Tokenizer.cs
@@ -98,7 +98,18 @@ namespace HandlebarsDotNet.Compiler.Lexer
                 }
                 else
                 {
-                    if ((char)node == '{' && (char)source.Peek() == '{')
+                    if ((char)node == '\\' && (char)source.Peek() == '{')
+                    {
+                        source.Read();
+                        if ((char)source.Peek() == '{')
+                        {
+                            source.Read();
+                            buffer.Append('{', 2);
+                        }
+
+                        node = source.Read();
+                    }
+                    else if ((char)node == '{' && (char)source.Peek() == '{')
                     {
                         bool escaped = true;
                         node = source.Read();


### PR DESCRIPTION
Moustache/Handlebars allows a backslash to escape template evaluation
````
\{{myValue}}
````

This PR adds that ability also.