### PR TITLE
More IDictionary<,> support and IReadOnlyDictionary<,> support

### DIFF
--- a/Handlebars.Net.nuspec
+++ b/Handlebars.Net.nuspec
@@ -14,6 +14,7 @@
         <releaseNotes>Note the root namespace changed from Handlebars to HandlebarsDotNet</releaseNotes>
     </metadata>
     <files>
-        <file src="source/Handlebars/bin/Release/Handlebars.dll" target="lib/Handlebars.dll" />
+        <file src="source/Handlebars/bin/Release/Net40/Handlebars.dll" target="lib/net40/Handlebars.dll" />
+        <file src="source/Handlebars/bin/Release/Net45/Handlebars.dll" target="lib/net45/Handlebars.dll" />
     </files>
 </package>

--- a/source/Handlebars.Test/BasicIntegrationTests.cs
+++ b/source/Handlebars.Test/BasicIntegrationTests.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Dynamic;
-using System.IO;
 using System.Collections;
 
 namespace HandlebarsDotNet.Test
@@ -55,6 +54,48 @@ namespace HandlebarsDotNet.Test
             var data = new
             {
                 names = new[] {new {name = "Foo"}, new {name = "Handlebars.Net"}}
+            };
+            var result = template(data);
+            Assert.AreEqual("Hello, Handlebars.Net!", result);
+        }
+
+        /// <summary>
+        /// Test basic path resolution against System.Collections.Hashtable.
+        /// This should test against the IDictionary checks within 
+        /// <see cref="HandlebarsDotNet.Compiler.PartialBinder.AccessMember()"/>
+        /// </summary>
+        [Test]
+        public void BasicPathHashtableTextKeyNoSquareBrackets()
+        {
+            var source = "Hello, {{ names.Foo }}!";
+            var template = Handlebars.Compile(source);
+            var data = new
+            {
+                names = new Hashtable
+                {
+                    { "Foo" , "Handlebars.Net" }
+                }
+            };
+            var result = template(data);
+            Assert.AreEqual("Hello, Handlebars.Net!", result);
+        }
+
+        // <summary>
+        /// Test basic path resolution against System.Collections.Hashtable.
+        /// This should test against the IDictionary checks within 
+        /// <see cref="HandlebarsDotNet.Compiler.PartialBinder.AccessMember()"/>
+        /// </summary>
+        [Test]
+        public void BasicPathHashtableTextKeySquareBrackets()
+        {
+            var source = "Hello, {{ names.[Foo] }}!";
+            var template = Handlebars.Compile(source);
+            var data = new
+            {
+                names = new Hashtable
+                {
+                    { "Foo" , "Handlebars.Net" }
+                }
             };
             var result = template(data);
             Assert.AreEqual("Hello, Handlebars.Net!", result);
@@ -206,6 +247,22 @@ namespace HandlebarsDotNet.Test
             };
             var result = template(data);
             Assert.AreEqual("Hello, Handlebars.Net!", result);
+        }
+
+        [Test]
+        public void BasicPathDictionaryInvalidPrimitiveKey()
+        {
+            var source = "Hello, {{ names.Foo }}!";
+            var template = Handlebars.Compile(source);
+            var data = new
+            {
+                names = new Dictionary<long, string>
+                {
+                    { 42 , "Handlebars.Net" }
+                }
+            };
+            var result = template(data);
+            Assert.AreEqual("Hello, !", result);
         }
 
         [Test]
@@ -722,10 +779,9 @@ namespace HandlebarsDotNet.Test
             {
                 dictionary = new MockDictionary()
             });
-            var expectedResult = 
-                "Hello world!";
+            var expectedResult = "Hello world!";
 
-            Assert.AreEqual(result, expectedResult);
+            Assert.AreEqual(expectedResult, result);
         }
 
         /// <summary>
@@ -787,7 +843,7 @@ namespace HandlebarsDotNet.Test
             }
             public bool ContainsKey(string key)
             {
-                throw new NotImplementedException();
+                return true;
             }
             public bool Remove(string key)
             {

--- a/source/Handlebars.Test/BasicIntegrationTests.cs
+++ b/source/Handlebars.Test/BasicIntegrationTests.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Dynamic;
 using System.IO;
+using System.Collections;
 
 namespace HandlebarsDotNet.Test
 {
@@ -76,6 +77,19 @@ namespace HandlebarsDotNet.Test
         }
 
         [Test]
+        public void BasicPathReadOnlyDictionaryTextKeyNoSquareBrackets()
+        {
+            var source = "Hello, {{ names.Foo }}!";
+            var template = Handlebars.Compile(source);
+            var data = new
+            {
+                names = new MockReadOnlyDictionary<string, string>("Foo", "Handlebars.Net")
+            };
+            var result = template(data);
+            Assert.AreEqual("Hello, Handlebars.Net!", result);
+        }
+
+        [Test]
         public void BasicPathDictionaryTextKey()
         {
             var source = "Hello, {{ names.[Foo] }}!";
@@ -92,6 +106,19 @@ namespace HandlebarsDotNet.Test
         }
 
         [Test]
+        public void BasicPathReadOnlyDictionaryTextKey()
+        {
+            var source = "Hello, {{ names.[Foo] }}!";
+            var template = Handlebars.Compile(source);
+            var data = new
+            {
+                names = new MockReadOnlyDictionary<string, string>("Foo", "Handlebars.Net")
+            };
+            var result = template(data);
+            Assert.AreEqual("Hello, Handlebars.Net!", result);
+        }
+
+        [Test]
         public void BasicPathDictionaryIntKeyNoSquareBrackets()
         {
             var source = "Hello, {{ names.42 }}!";
@@ -102,6 +129,19 @@ namespace HandlebarsDotNet.Test
                 {
                     { 42 , "Handlebars.Net" }
                 }
+            };
+            var result = template(data);
+            Assert.AreEqual("Hello, Handlebars.Net!", result);
+        }
+
+        [Test]
+        public void BasicPathReadOnlyDictionaryIntKeyNoSquareBrackets()
+        {
+            var source = "Hello, {{ names.42 }}!";
+            var template = Handlebars.Compile(source);
+            var data = new
+            {
+                names = new MockReadOnlyDictionary<int, string>(42, "Handlebars.Net")
             };
             var result = template(data);
             Assert.AreEqual("Hello, Handlebars.Net!", result);
@@ -134,6 +174,19 @@ namespace HandlebarsDotNet.Test
                 {
                     { 42 , "Handlebars.Net" }
                 }
+            };
+            var result = template(data);
+            Assert.AreEqual("Hello, Handlebars.Net!", result);
+        }
+
+        [Test]
+        public void BasicPathReadOnlyDictionaryIntKey()
+        {
+            var source = "Hello, {{ names.[42] }}!";
+            var template = Handlebars.Compile(source);
+            var data = new
+            {
+                names = new MockReadOnlyDictionary<int, string>(42, "Handlebars.Net")
             };
             var result = template(data);
             Assert.AreEqual("Hello, Handlebars.Net!", result);
@@ -673,6 +726,57 @@ namespace HandlebarsDotNet.Test
                 "Hello world!";
 
             Assert.AreEqual(result, expectedResult);
+        }
+
+        /// <summary>
+        /// Mock ReadOnlyDictionary.
+        /// </summary>
+        /// <typeparam name="TKey"></typeparam>
+        /// <typeparam name="TValue"></typeparam>
+        private class MockReadOnlyDictionary<TKey, TValue> : IReadOnlyDictionary<TKey, TValue>
+        {
+            Dictionary<TKey, TValue> _internal;
+
+            public MockReadOnlyDictionary(TKey key, TValue value)
+            {
+                _internal = new Dictionary<TKey, TValue>
+                {
+                    { key, value }
+                };
+            }
+
+            public MockReadOnlyDictionary(Dictionary<TKey, TValue> dict)
+            {
+                _internal = dict;
+            }
+
+            public TValue this[TKey key] { get { return _internal[key]; } }
+
+            public int Count { get { return _internal.Count; } }
+
+            public IEnumerable<TKey> Keys { get { return _internal.Keys; } }
+
+            public IEnumerable<TValue> Values { get { return _internal.Values; } }
+
+            public bool ContainsKey(TKey key)
+            {
+                return _internal.ContainsKey(key);
+            }
+
+            public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
+            {
+                return _internal.GetEnumerator();
+            }
+
+            public bool TryGetValue(TKey key, out TValue value)
+            {
+                return _internal.TryGetValue(key, out value);
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return _internal.GetEnumerator();
+            }
         }
 
         private class MockDictionary : IDictionary<string, string>

--- a/source/Handlebars.Test/BasicIntegrationTests.cs
+++ b/source/Handlebars.Test/BasicIntegrationTests.cs
@@ -45,7 +45,7 @@ namespace HandlebarsDotNet.Test
             var result = template(data);
             Assert.AreEqual("Hello, Handlebars.Net!", result);
         }
-
+        
         [Test]
         public void BasicPathArrayChildPath()
         {
@@ -54,6 +54,102 @@ namespace HandlebarsDotNet.Test
             var data = new
             {
                 names = new[] {new {name = "Foo"}, new {name = "Handlebars.Net"}}
+            };
+            var result = template(data);
+            Assert.AreEqual("Hello, Handlebars.Net!", result);
+        }
+
+        [Test]
+        public void BasicPathDictionaryTextKeyNoSquareBrackets()
+        {
+            var source = "Hello, {{ names.Foo }}!";
+            var template = Handlebars.Compile(source);
+            var data = new
+            {
+                names = new Dictionary<string, string>
+                {
+                    { "Foo" , "Handlebars.Net" }
+                }
+            };
+            var result = template(data);
+            Assert.AreEqual("Hello, Handlebars.Net!", result);
+        }
+
+        [Test]
+        public void BasicPathDictionaryTextKey()
+        {
+            var source = "Hello, {{ names.[Foo] }}!";
+            var template = Handlebars.Compile(source);
+            var data = new
+            {
+                names = new Dictionary<string, string>
+                {
+                    { "Foo" , "Handlebars.Net" }
+                }
+            };
+            var result = template(data);
+            Assert.AreEqual("Hello, Handlebars.Net!", result);
+        }
+
+        [Test]
+        public void BasicPathDictionaryIntKeyNoSquareBrackets()
+        {
+            var source = "Hello, {{ names.42 }}!";
+            var template = Handlebars.Compile(source);
+            var data = new
+            {
+                names = new Dictionary<int, string>
+                {
+                    { 42 , "Handlebars.Net" }
+                }
+            };
+            var result = template(data);
+            Assert.AreEqual("Hello, Handlebars.Net!", result);
+        }
+
+        [Test]
+        public void BasicPathDictionaryLongKeyNoSquareBrackets()
+        {
+            var source = "Hello, {{ names.42 }}!";
+            var template = Handlebars.Compile(source);
+            var data = new
+            {
+                names = new Dictionary<long, string>
+                {
+                    { 42 , "Handlebars.Net" }
+                }
+            };
+            var result = template(data);
+            Assert.AreEqual("Hello, Handlebars.Net!", result);
+        }
+
+        [Test]
+        public void BasicPathDictionaryIntKey()
+        {
+            var source = "Hello, {{ names.[42] }}!";
+            var template = Handlebars.Compile(source);
+            var data = new
+            {
+                names = new Dictionary<int, string>
+                {
+                    { 42 , "Handlebars.Net" }
+                }
+            };
+            var result = template(data);
+            Assert.AreEqual("Hello, Handlebars.Net!", result);
+        }
+
+        [Test]
+        public void BasicPathDictionaryLongKey()
+        {
+            var source = "Hello, {{ names.[42] }}!";
+            var template = Handlebars.Compile(source);
+            var data = new
+            {
+                names = new Dictionary<long, string>
+                {
+                    { 42 , "Handlebars.Net" }
+                }
             };
             var result = template(data);
             Assert.AreEqual("Hello, Handlebars.Net!", result);
@@ -205,7 +301,7 @@ namespace HandlebarsDotNet.Test
             var result = template(data);
             Assert.AreEqual("hello world ", result);
         }
-
+        
         [Test]
         public void BasicDictionaryEnumeratorWithKey()
         {

--- a/source/Handlebars.Test/Handlebars.Test.csproj
+++ b/source/Handlebars.Test/Handlebars.Test.csproj
@@ -79,6 +79,9 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/source/Handlebars.sln
+++ b/source/Handlebars.sln
@@ -1,6 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
+# Visual Studio 14
+VisualStudioVersion = 14.0.22823.1
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Handlebars", "Handlebars\Handlebars.csproj", "{A09CFF95-B671-48FE-96A8-D3CBDC110B75}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Handlebars.Test", "Handlebars.Test\Handlebars.Test.csproj", "{2BD48FB6-C852-4141-B734-12E501B1D761}"
@@ -12,6 +14,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{B3E309
 		.nuget\NuGet.targets = .nuget\NuGet.targets
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Handlebars.Net40", "Handlebars\Handlebars.Net40.csproj", "{6F2214A4-B095-4A36-A16D-DC755BF2AD32}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -22,6 +26,16 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A09CFF95-B671-48FE-96A8-D3CBDC110B75}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A09CFF95-B671-48FE-96A8-D3CBDC110B75}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A09CFF95-B671-48FE-96A8-D3CBDC110B75}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{A09CFF95-B671-48FE-96A8-D3CBDC110B75}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{A09CFF95-B671-48FE-96A8-D3CBDC110B75}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A09CFF95-B671-48FE-96A8-D3CBDC110B75}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A09CFF95-B671-48FE-96A8-D3CBDC110B75}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A09CFF95-B671-48FE-96A8-D3CBDC110B75}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{A09CFF95-B671-48FE-96A8-D3CBDC110B75}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{A09CFF95-B671-48FE-96A8-D3CBDC110B75}.Release|x86.ActiveCfg = Release|Any CPU
 		{2BD48FB6-C852-4141-B734-12E501B1D761}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{2BD48FB6-C852-4141-B734-12E501B1D761}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2BD48FB6-C852-4141-B734-12E501B1D761}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
@@ -34,18 +48,21 @@ Global
 		{2BD48FB6-C852-4141-B734-12E501B1D761}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{2BD48FB6-C852-4141-B734-12E501B1D761}.Release|x86.ActiveCfg = Release|Any CPU
 		{2BD48FB6-C852-4141-B734-12E501B1D761}.Release|x86.Build.0 = Release|Any CPU
-		{A09CFF95-B671-48FE-96A8-D3CBDC110B75}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{A09CFF95-B671-48FE-96A8-D3CBDC110B75}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{A09CFF95-B671-48FE-96A8-D3CBDC110B75}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{A09CFF95-B671-48FE-96A8-D3CBDC110B75}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
-		{A09CFF95-B671-48FE-96A8-D3CBDC110B75}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{A09CFF95-B671-48FE-96A8-D3CBDC110B75}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{A09CFF95-B671-48FE-96A8-D3CBDC110B75}.Release|Any CPU.Build.0 = Release|Any CPU
-		{A09CFF95-B671-48FE-96A8-D3CBDC110B75}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
-		{A09CFF95-B671-48FE-96A8-D3CBDC110B75}.Release|Mixed Platforms.Build.0 = Release|Any CPU
-		{A09CFF95-B671-48FE-96A8-D3CBDC110B75}.Release|x86.ActiveCfg = Release|Any CPU
+		{6F2214A4-B095-4A36-A16D-DC755BF2AD32}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6F2214A4-B095-4A36-A16D-DC755BF2AD32}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6F2214A4-B095-4A36-A16D-DC755BF2AD32}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{6F2214A4-B095-4A36-A16D-DC755BF2AD32}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{6F2214A4-B095-4A36-A16D-DC755BF2AD32}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6F2214A4-B095-4A36-A16D-DC755BF2AD32}.Debug|x86.Build.0 = Debug|Any CPU
+		{6F2214A4-B095-4A36-A16D-DC755BF2AD32}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6F2214A4-B095-4A36-A16D-DC755BF2AD32}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6F2214A4-B095-4A36-A16D-DC755BF2AD32}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{6F2214A4-B095-4A36-A16D-DC755BF2AD32}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{6F2214A4-B095-4A36-A16D-DC755BF2AD32}.Release|x86.ActiveCfg = Release|Any CPU
+		{6F2214A4-B095-4A36-A16D-DC755BF2AD32}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		StartupItem = Handlebars\Handlebars.csproj
@@ -86,8 +103,5 @@ Global
 		$3.DirectoryNamespaceAssociation = None
 		$3.ResourceNamePolicy = FileFormatDefault
 		version = 1.0.0
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/source/Handlebars/Compiler/Translation/Expression/PathBinder.cs
+++ b/source/Handlebars/Compiler/Translation/Expression/PathBinder.cs
@@ -188,7 +188,14 @@ namespace HandlebarsDotNet.Compiler
             
             var iDictInstance = instanceType.GetInterfaces()
                     .FirstOrDefault(i => i.IsGenericType
-                        && i.GetGenericTypeDefinition() == typeof(IDictionary<,>));
+                        &&
+                        (
+                        i.GetGenericTypeDefinition() == typeof(IDictionary<,>)
+#if NET45
+                        || i.GetGenericTypeDefinition() == typeof(IReadOnlyDictionary<,>)
+#endif
+                        )
+                    );
             if (iDictInstance != null)
             {
                 var genericArgs = iDictInstance.GetGenericArguments();

--- a/source/Handlebars/Handlebars.Net40.csproj
+++ b/source/Handlebars/Handlebars.Net40.csproj
@@ -15,7 +15,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug</OutputPath>
+    <OutputPath>bin\Debug\Net40</OutputPath>
     <IntermediateOutputPath>obj\Debug\Net40\</IntermediateOutputPath>
     <DefineConstants>DEBUG;NET40</DefineConstants>
     <ErrorReport>prompt</ErrorReport>

--- a/source/Handlebars/Handlebars.Net40.csproj
+++ b/source/Handlebars/Handlebars.Net40.csproj
@@ -3,11 +3,11 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{A09CFF95-B671-48FE-96A8-D3CBDC110B75}</ProjectGuid>
+    <ProjectGuid>{6F2214A4-B095-4A36-A16D-DC755BF2AD32}</ProjectGuid>
     <OutputType>Library</OutputType>
     <RootNamespace>Handlebars</RootNamespace>
     <AssemblyName>Handlebars</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <TargetFrameworkProfile />
     <ReleaseVersion>1.0.0</ReleaseVersion>
   </PropertyGroup>
@@ -16,21 +16,19 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug</OutputPath>
-    <IntermediateOutputPath>obj\Debug\Net45\</IntermediateOutputPath>
-    <DefineConstants>DEBUG;NET45</DefineConstants>
+    <IntermediateOutputPath>obj\Debug\Net40\</IntermediateOutputPath>
+    <DefineConstants>DEBUG;NET40</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Externalconsole>true</Externalconsole>
-    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>false</Optimize>
-    <OutputPath>bin\Release\Net45\</OutputPath>
-    <IntermediateOutputPath>obj\Release\Net45\</IntermediateOutputPath>
+    <OutputPath>bin\Release\Net40\</OutputPath>
+    <IntermediateOutputPath>obj\Debug\Net40\</IntermediateOutputPath>
     <WarningLevel>4</WarningLevel>
     <AssemblyOriginatorKeyFile>..\..\handlebars.net.snk</AssemblyOriginatorKeyFile>
-    <Prefer32Bit>false</Prefer32Bit>
-    <DefineConstants>NET45</DefineConstants>
+    <DefineConstants>NET40</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/source/Handlebars/Handlebars.csproj
+++ b/source/Handlebars/Handlebars.csproj
@@ -15,7 +15,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug</OutputPath>
+    <OutputPath>bin\Debug\Net45</OutputPath>
     <IntermediateOutputPath>obj\Debug\Net45\</IntermediateOutputPath>
     <DefineConstants>DEBUG;NET45</DefineConstants>
     <ErrorReport>prompt</ErrorReport>


### PR DESCRIPTION
I added I more tests and support for Dictionaries with key types other than string. I also added in support for IReadOnlyDictionary, which requires .Net 4.5+. To handle this, I created a secondary Handlebars.Net40 proj that targets that and PCL. The nuspec file is setup to include both into framework folders.

If splitting out into multiple csproj files to handle the different frameworks seems too much, I can drop support for IReadOnlyDictionary<,> and just keep the expanded IDictionary<,> stuff.

All unit tests passing locally.