### PR TITLE
Fix numeric args getting stripped of first char

### DIFF
--- a/source/Handlebars.Test/HelperTests.cs
+++ b/source/Handlebars.Test/HelperTests.cs
@@ -142,6 +142,28 @@ namespace HandlebarsDotNet.Test
             Assert.AreEqual(expectedIsSame, outputIsSame);
             Assert.AreEqual(expectedIsDifferent, outputIsDifferent);
         }
+
+        [Test]
+        public void HelperWithNumericArguments()
+        {
+            Handlebars.RegisterHelper("myHelper", (writer, context, args) => {
+                var count = 0;
+                foreach(var arg in args)
+                {
+                    writer.Write("\nThing {0}: {1}", ++count, arg);
+                }
+            });
+
+            var source = "Here are some things: {{myHelper 123 4567 -98.76}}";
+
+            var template = Handlebars.Compile(source);
+
+            var output = template(new { });
+
+            var expected = "Here are some things: \nThing 1: 123\nThing 2: 4567\nThing 3: -98.76";
+
+            Assert.AreEqual(expected, output);
+        }
     }
 }
 

--- a/source/Handlebars/Compiler/Lexer/Parsers/LiteralParser.cs
+++ b/source/Handlebars/Compiler/Lexer/Parsers/LiteralParser.cs
@@ -12,12 +12,12 @@ namespace HandlebarsDotNet.Compiler.Lexer
             if (IsDelimitedLiteral(reader) == true)
             {
                 char delimiter = (char)reader.Read();
-                var buffer = AccumulateLiteral(reader, delimiter);
+                var buffer = AccumulateLiteral(reader, delimiter, true);
                 token = Token.Literal(buffer, delimiter.ToString());
             }
             else if (IsNonDelimitedLiteral(reader) == true)
             {
-                var buffer = AccumulateLiteral(reader, ' ');
+                var buffer = AccumulateLiteral(reader, ' ', false);
                 token = Token.Literal(buffer);
             }
             return token;
@@ -35,7 +35,7 @@ namespace HandlebarsDotNet.Compiler.Lexer
             return char.IsDigit(peek) || peek == '-';
         }
 
-        private static string AccumulateLiteral(TextReader reader, char delimiter)
+        private static string AccumulateLiteral(TextReader reader, char delimiter, bool captureDelimiter)
         {
             StringBuilder buffer = new StringBuilder();
             while (true)
@@ -49,7 +49,10 @@ namespace HandlebarsDotNet.Compiler.Lexer
                 {
                     if ((char)node == delimiter)
                     {
-                        reader.Read();
+                        if (captureDelimiter)
+                        {
+                            reader.Read();
+                        }
                         break;
                     }
                     else if ((char)node == '}')


### PR DESCRIPTION
After the first argument to a helper, all subsequent numeric literal arguments were being stripped of their first character. For example, `4567` was passed to the helper as `567`.