### PR TITLE
Add instance to ResolveExpressionName

### DIFF
--- a/source/Handlebars/Compiler/Resolvers/IExpressionNameResolver.cs
+++ b/source/Handlebars/Compiler/Resolvers/IExpressionNameResolver.cs
@@ -2,6 +2,6 @@
 {
     public interface IExpressionNameResolver
     {
-        string ResolveExpressionName(string expressionName);
+        string ResolveExpressionName(object instance, string expressionName);
     }
 }

--- a/source/Handlebars/Compiler/Resolvers/UpperCamelCaseExpressionNameResolver.cs
+++ b/source/Handlebars/Compiler/Resolvers/UpperCamelCaseExpressionNameResolver.cs
@@ -4,7 +4,7 @@ namespace HandlebarsDotNet.Compiler.Resolvers
 {
     public class UpperCamelCaseExpressionNameResolver : IExpressionNameResolver
     {
-        public string ResolveExpressionName(string expressionName)
+        public string ResolveExpressionName(object instance, string expressionName)
         {
             if (string.IsNullOrEmpty(expressionName))
             {

--- a/source/Handlebars/Compiler/Translation/Expression/PathBinder.cs
+++ b/source/Handlebars/Compiler/Translation/Expression/PathBinder.cs
@@ -160,7 +160,7 @@ namespace HandlebarsDotNet.Compiler
                     return result ?? new UndefinedBindingResult();
                 }
             }
-            var resolvedMemberName = this.ResolveMemberName(memberName);
+            var resolvedMemberName = this.ResolveMemberName(instance, memberName);
             var instanceType = instance.GetType();
             //crude handling for dynamic objects that don't have metadata
             if (typeof(IDynamicMetaObjectProvider).IsAssignableFrom(instanceType))
@@ -261,10 +261,10 @@ namespace HandlebarsDotNet.Compiler
             return site.Target(site, target);
         }
 
-        private string ResolveMemberName(string memberName)
+        private string ResolveMemberName(object instance, string memberName)
         {
             var resolver = this.CompilationContext.Configuration.ExpressionNameResolver;
-            return resolver != null ? resolver.ResolveExpressionName(memberName) : memberName;
+            return resolver != null ? resolver.ResolveExpressionName(instance, memberName) : memberName;
         }
     }
 }


### PR DESCRIPTION
My naming conventions are lower_case for my json objects, but I have unknown items in dictionaries that I need to leave the casing alone on. Without access to the contextual information of what object I am resolving the member name for, I don't know what format to use.