### PR TITLE
Add support for passing hash parameters to partials

### DIFF
--- a/source/Handlebars.Test/PartialTests.cs
+++ b/source/Handlebars.Test/PartialTests.cs
@@ -74,7 +74,7 @@ namespace HandlebarsDotNet.Test
         [Test]
         public void BasicPartialWithMultipleStringParameters()
         {
-            string source = "Hello, {{>person first='Pete' last='Sampras'}}!";
+            string source = "Hello, {{>person first='Pete' last=\"Sampras\"}}!";
 
             var template = Handlebars.Compile(source);
 

--- a/source/Handlebars.Test/PartialTests.cs
+++ b/source/Handlebars.Test/PartialTests.cs
@@ -53,6 +53,117 @@ namespace HandlebarsDotNet.Test
             Assert.AreEqual("Hello, Marc!", result);
         }
 
+        [Test]
+        public void BasicPartialWithStringParameter()
+        {
+            string source = "Hello, {{>person first='Pete'}}!";
+
+            var template = Handlebars.Compile(source);
+
+            var partialSource = "{{first}}";
+            using (var reader = new StringReader(partialSource))
+            {
+                var partialTemplate = Handlebars.Compile(reader);
+                Handlebars.RegisterTemplate("person", partialTemplate);
+            }
+
+            var result = template(null);
+            Assert.AreEqual("Hello, Pete!", result);
+        }
+
+        [Test]
+        public void BasicPartialWithMultipleStringParameters()
+        {
+            string source = "Hello, {{>person first='Pete' last='Sampras'}}!";
+
+            var template = Handlebars.Compile(source);
+
+            var partialSource = "{{first}} {{last}}";
+            using (var reader = new StringReader(partialSource))
+            {
+                var partialTemplate = Handlebars.Compile(reader);
+                Handlebars.RegisterTemplate("person", partialTemplate);
+            }
+
+            var result = template(null);
+            Assert.AreEqual("Hello, Pete Sampras!", result);
+        }
+
+        [Test]
+        public void BasicPartialWithContextParameter()
+        {
+            string source = "Hello, {{>person first=leadDev.marc}}!";
+
+            var template = Handlebars.Compile(source);
+
+            var data = new
+            {
+                leadDev = new
+                {
+                    marc = new
+                    {
+                        name = "Marc"
+                    }
+                }
+            };
+
+            var partialSource = "{{first.name}}";
+            using (var reader = new StringReader(partialSource))
+            {
+                var partialTemplate = Handlebars.Compile(reader);
+                Handlebars.RegisterTemplate("person", partialTemplate);
+            }
+
+            var result = template(data);
+            Assert.AreEqual("Hello, Marc!", result);
+        }
+
+        [Test]
+        public void BasicPartialWithContextAndStringParameters()
+        {
+            string source = "Hello, {{>person first=leadDev.marc last='Smith'}}!";
+
+            var template = Handlebars.Compile(source);
+
+            var data = new
+            {
+                leadDev = new
+                {
+                    marc = new
+                    {
+                        name = "Marc"
+                    }
+                }
+            };
+
+            var partialSource = "{{first.name}} {{last}}";
+            using (var reader = new StringReader(partialSource))
+            {
+                var partialTemplate = Handlebars.Compile(reader);
+                Handlebars.RegisterTemplate("person", partialTemplate);
+            }
+
+            var result = template(data);
+            Assert.AreEqual("Hello, Marc Smith!", result);
+        }
+
+        [Test]
+        public void BasicPartialWithTypedParameters()
+        {
+            string source = "Hello, {{>person first=1 last=true}}!";
+
+            var template = Handlebars.Compile(source);
+
+            var partialSource = "{{first}} {{last}}";
+            using (var reader = new StringReader(partialSource))
+            {
+                var partialTemplate = Handlebars.Compile(reader);
+                Handlebars.RegisterTemplate("person", partialTemplate);
+            }
+
+            var result = template(null);
+            Assert.AreEqual("Hello, 1 True!", result);
+        }
 
         [Test]
         public void SuperfluousWhitespace()

--- a/source/Handlebars/Compiler/ExpressionBuilder.cs
+++ b/source/Handlebars/Compiler/ExpressionBuilder.cs
@@ -24,6 +24,7 @@ namespace HandlebarsDotNet.Compiler
             tokens = CommentRemover.Remove(tokens);
             tokens = LiteralConverter.Convert(tokens);
             tokens = HelperConverter.Convert(tokens, _configuration);
+            tokens = HashParametersConverter.Convert(tokens);
             tokens = PathConverter.Convert(tokens);
             tokens = PartialConverter.Convert(tokens);
             tokens = SubExpressionConverter.Convert(tokens);

--- a/source/Handlebars/Compiler/Lexer/Converter/HashParametersConverter.cs
+++ b/source/Handlebars/Compiler/Lexer/Converter/HashParametersConverter.cs
@@ -63,9 +63,9 @@ namespace HandlebarsDotNet.Compiler
 
         private static object ParseValue(string value)
         {
-            if (value.StartsWith("'"))
+            if (value.StartsWith("'") || value.StartsWith("\""))
             {
-                return value.Trim('\'');
+                return value.Trim('\'', '"');
             }
 
             bool boolValue;

--- a/source/Handlebars/Compiler/Lexer/Converter/HashParametersConverter.cs
+++ b/source/Handlebars/Compiler/Lexer/Converter/HashParametersConverter.cs
@@ -1,0 +1,95 @@
+﻿using System.Collections.Generic;
+using HandlebarsDotNet.Compiler.Lexer;
+using System.Linq;
+
+namespace HandlebarsDotNet.Compiler
+{
+    internal class HashParametersConverter : TokenConverter
+    {
+        public static IEnumerable<object> Convert(IEnumerable<object> sequence)
+        {
+            return new HashParametersConverter().ConvertTokens(sequence).ToList();
+        }
+
+        private HashParametersConverter() { }
+
+        public override IEnumerable<object> ConvertTokens(IEnumerable<object> sequence)
+        {
+            var enumerator = sequence.GetEnumerator();
+            while (enumerator.MoveNext())
+            {
+                var item = enumerator.Current;
+
+                if (item is HashParameterToken)
+                {
+                    var parameters = AccumulateParameters(enumerator);
+
+                    if (parameters.Any())
+                    {
+                        yield return HandlebarsExpression.HashParametersExpression(parameters);
+                    }
+
+                    yield return enumerator.Current;
+                }
+                else
+                {
+                    yield return item;
+                }
+            }
+        }
+
+        private static Dictionary<string, object> AccumulateParameters(IEnumerator<object> enumerator)
+        {
+            var parameters = new Dictionary<string, object>();
+
+            var item = enumerator.Current;
+
+            while ((item is EndExpressionToken) == false)
+            {
+                var parameter = item as HashParameterToken;
+
+                if (parameter != null)
+                {
+                    var segments = parameter.Value.Split('=');
+                    var value = ParseValue(segments[1]);
+                    parameters.Add(segments[0], value);
+                }
+
+                item = GetNext(enumerator);
+            }
+
+            return parameters;
+        }
+
+        private static object ParseValue(string value)
+        {
+            if (value.StartsWith("'"))
+            {
+                return value.Trim('\'');
+            }
+
+            bool boolValue;
+
+            if (bool.TryParse(value, out boolValue))
+            {
+                return boolValue;
+            }
+
+            int intValue;
+
+            if (int.TryParse(value, out intValue))
+            {
+                return intValue;
+            }
+
+            return HandlebarsExpression.Path(value);
+        }
+
+        private static object GetNext(IEnumerator<object> enumerator)
+        {
+            enumerator.MoveNext();
+            return enumerator.Current;
+        }
+    }
+}
+

--- a/source/Handlebars/Compiler/Lexer/Parsers/WordParser.cs
+++ b/source/Handlebars/Compiler/Lexer/Parsers/WordParser.cs
@@ -11,13 +11,20 @@ namespace HandlebarsDotNet.Compiler.Lexer
 
         public override Token Parse(TextReader reader)
         {
-            WordExpressionToken token = null;
             if (IsWord(reader))
             {
                 var buffer = AccumulateWord(reader);
-                token = Token.Word(buffer);
+
+                if (buffer.Contains("="))
+                {
+                    return Token.HashParameter(buffer);
+                }
+                else
+                {
+                    return Token.Word(buffer);
+                }
             }
-            return token;
+            return null;
         }
 
         private bool IsWord(TextReader reader)

--- a/source/Handlebars/Compiler/Lexer/Tokens/HashParameterToken.cs
+++ b/source/Handlebars/Compiler/Lexer/Tokens/HashParameterToken.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace HandlebarsDotNet.Compiler.Lexer
+{
+    internal class HashParameterToken : ExpressionToken
+    {
+        private readonly string _parameter;
+
+        public HashParameterToken(string parameter)
+        {
+            _parameter = parameter;
+        }
+
+        public override TokenType Type
+        {
+            get { return TokenType.HashParameter; }
+        }
+
+        public override string Value
+        {
+            get { return _parameter; }
+        }
+    }
+}
+

--- a/source/Handlebars/Compiler/Lexer/Tokens/Token.cs
+++ b/source/Handlebars/Compiler/Lexer/Tokens/Token.cs
@@ -57,6 +57,11 @@ namespace HandlebarsDotNet.Compiler.Lexer
         {
             return new EndSubExpressionToken();
         }
+
+        public static HashParameterToken HashParameter(string parameter)
+        {
+            return new HashParameterToken(parameter);
+        }
     }
 }
 

--- a/source/Handlebars/Compiler/Lexer/Tokens/TokenType.cs
+++ b/source/Handlebars/Compiler/Lexer/Tokens/TokenType.cs
@@ -14,7 +14,8 @@ namespace HandlebarsDotNet.Compiler.Lexer
         Partial = 7,
         Layout = 8,
         StartSubExpression = 9,
-        EndSubExpression = 10
+        EndSubExpression = 10,
+        HashParameter = 11
     }
 }
 

--- a/source/Handlebars/Compiler/Structure/HandlebarsExpression.cs
+++ b/source/Handlebars/Compiler/Structure/HandlebarsExpression.cs
@@ -16,7 +16,8 @@ namespace HandlebarsDotNet.Compiler
         DeferredSection = 6007,
         PartialExpression = 6008,
         BoolishExpression = 6009,
-        SubExpression = 6010
+        SubExpression = 6010,
+        HashParametersExpression = 6011
     }
 
     internal abstract class HandlebarsExpression : Expression
@@ -101,6 +102,11 @@ namespace HandlebarsDotNet.Compiler
         public static SubExpressionExpression SubExpression(Expression expression)
         {
             return new SubExpressionExpression(expression);
+        }
+
+        public static HashParametersExpression HashParametersExpression(Dictionary<string, object> parameters)
+        {
+            return new HashParametersExpression(parameters);
         }
     }
 }

--- a/source/Handlebars/Compiler/Structure/HashParametersExpression.cs
+++ b/source/Handlebars/Compiler/Structure/HashParametersExpression.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace HandlebarsDotNet.Compiler
+{
+    internal class HashParametersExpression : HandlebarsExpression
+    {
+        public Dictionary<string, object> Parameters { get; set; }
+
+        public HashParametersExpression(Dictionary<string, object> parameters)
+        {
+            Parameters = parameters;
+        }
+
+        public override ExpressionType NodeType
+        {
+            get { return (ExpressionType)HandlebarsExpressionType.HashParametersExpression; }
+        }
+
+        public override Type Type
+        {
+            get { return typeof(object); }
+        }
+    }
+}
+

--- a/source/Handlebars/Compiler/Translation/Expression/HandlebarsExpressionVisitor.cs
+++ b/source/Handlebars/Compiler/Translation/Expression/HandlebarsExpressionVisitor.cs
@@ -33,6 +33,8 @@ namespace HandlebarsDotNet.Compiler
                     return VisitHelperExpression((HelperExpression)exp);
                 case HandlebarsExpressionType.BlockExpression:
                     return VisitBlockHelperExpression((BlockHelperExpression)exp);
+                case HandlebarsExpressionType.HashParametersExpression:
+                    return VisitHashParametersExpression((HashParametersExpression)exp);
                 case HandlebarsExpressionType.PathExpression:
                     return VisitPathExpression((PathExpression)exp);
                 case HandlebarsExpressionType.ContextAccessorExpression:
@@ -105,6 +107,11 @@ namespace HandlebarsDotNet.Compiler
         protected virtual Expression VisitSubExpression(SubExpressionExpression subex)
         {
             return subex;
+        }
+
+        protected virtual Expression VisitHashParametersExpression(HashParametersExpression hpex)
+        {
+            return hpex;
         }
     }
 }

--- a/source/Handlebars/Compiler/Translation/Expression/PathBinder.cs
+++ b/source/Handlebars/Compiler/Translation/Expression/PathBinder.cs
@@ -94,6 +94,36 @@ namespace HandlebarsDotNet.Compiler
                 hex.Arguments.Select(arg => Visit(arg)));
         }
 
+        protected override Expression VisitHashParametersExpression(HashParametersExpression hpex)
+        {
+            return Expression.Call(
+                Expression.Constant(this),
+                new Func<BindingContext, HashParametersExpression, object>(ResolveParameters).Method,
+                CompilationContext.BindingContext,
+                Expression.Constant(hpex));
+        }
+
+        private object ResolveParameters(BindingContext context, HashParametersExpression hpex)
+        {
+            var parameters = new Dictionary<string, object>();
+
+            foreach (var parameter in hpex.Parameters)
+            {
+                var path = parameter.Value as PathExpression;
+
+                if (path != null)
+                {
+                    parameters.Add(parameter.Key, ResolvePath(context, path.Path));
+                }
+                else
+                {
+                    parameters.Add(parameter.Key, parameter.Value);
+                }
+            }
+
+            return parameters;
+        }
+
         //TODO: make path resolution logic smarter
         private object ResolvePath(BindingContext context, string path)
         {

--- a/source/Handlebars/Handlebars.csproj
+++ b/source/Handlebars/Handlebars.csproj
@@ -37,10 +37,13 @@
   <ItemGroup>
     <Compile Include="Compiler\CompilationContext.cs" />
     <Compile Include="Compiler\ExpressionBuilder.cs" />
+    <Compile Include="Compiler\Lexer\Converter\HashParametersConverter.cs" />
     <Compile Include="Compiler\Lexer\Converter\LayoutRemover.cs" />
+    <Compile Include="Compiler\Lexer\Tokens\HashParameterToken.cs" />
     <Compile Include="Compiler\Lexer\Tokens\LayoutToken.cs" />
     <Compile Include="Compiler\Resolvers\UpperCamelCaseExpressionNameResolver.cs" />
     <Compile Include="Compiler\Resolvers\IExpressionNameResolver.cs" />
+    <Compile Include="Compiler\Structure\HashParametersExpression.cs" />
     <Compile Include="Compiler\Translation\Expression\HelperFunctionBinder.cs" />
     <Compile Include="DescriptionAttribute.cs" />
     <Compile Include="EnumerableExtensions.cs" />


### PR DESCRIPTION
This library is awesome, but I really wanted to be able to pass a bunch of parameters to a partial that were not in the root context (http://handlebarsjs.com/partials.html#partial-parameters).

I've added a new HashParameters expression that contains a collection of key value pairs (string, object) to achieve this. It supports the value being a string, int, bool or a context path.

e.g. `{{>person pie=1 foo=true bar="hello" name=leadDev.name }}`

I didn't have a massive amount of time to spend but I have written a bunch of unit tests and everything looks good.

Let me know what you think.