### PR TITLE
Add support for dynamic partials

### DIFF
--- a/source/Handlebars.Test/PartialTests.cs
+++ b/source/Handlebars.Test/PartialTests.cs
@@ -166,6 +166,87 @@ namespace HandlebarsDotNet.Test
         }
 
         [Test]
+        public void DynamicPartial()
+        {
+            string source = "Hello, {{> (partialNameHelper)}}!";
+
+            Handlebars.RegisterHelper("partialNameHelper", (writer, context, args) =>
+            {
+                writer.WriteSafeString("partialName");
+            });
+
+            using (var reader = new StringReader("world"))
+            {
+                var partial = Handlebars.Compile(reader);
+                Handlebars.RegisterTemplate("partialName", partial);
+            }
+
+            var template = Handlebars.Compile(source);
+            var data = new { };
+            var result = template(data);
+            Assert.AreEqual("Hello, world!", result);
+        }
+
+        [Test]
+        public void DynamicPartialWithContext()
+        {
+            var source = "Hello, {{> (lookup name) context }}!";
+
+            Handlebars.RegisterHelper("lookup", (output, context, arguments) =>
+            {
+                output.WriteSafeString(arguments[0]);
+            });
+
+            var template = Handlebars.Compile(source);
+
+            using (var reader = new StringReader("{{first}} {{last}}"))
+            {
+                var partialTemplate = Handlebars.Compile(reader);
+                Handlebars.RegisterTemplate("test", partialTemplate);
+            }
+
+            var data = new
+            {
+                name = "test",
+                context = new
+                {
+                    first = "Marc",
+                    last = "Smith"
+                }
+            };
+
+            var result = template(data);
+            Assert.AreEqual("Hello, Marc Smith!", result);
+        }
+
+        [Test]
+        public void DynamicPartialWithParameters()
+        {
+            var source = "Hello, {{> (lookup name) first='Marc' last='Smith' }}!";
+
+            Handlebars.RegisterHelper("lookup", (output, context, arguments) =>
+            {
+                output.WriteSafeString(arguments[0]);
+            });
+
+            var template = Handlebars.Compile(source);
+
+            using (var reader = new StringReader("{{first}} {{last}}"))
+            {
+                var partialTemplate = Handlebars.Compile(reader);
+                Handlebars.RegisterTemplate("test", partialTemplate);
+            }
+
+            var data = new
+            {
+                name = "test"
+            };
+
+            var result = template(data);
+            Assert.AreEqual("Hello, Marc Smith!", result);
+        }
+
+        [Test]
         public void SuperfluousWhitespace()
         {
             string source = "Hello, {{  >  person  }}!";

--- a/source/Handlebars.Test/PartialTests.cs
+++ b/source/Handlebars.Test/PartialTests.cs
@@ -188,6 +188,28 @@ namespace HandlebarsDotNet.Test
         }
 
         [Test]
+        public void DynamicPartialWithHelperArguments()
+        {
+            string source = "Hello, {{> (concat 'partial' 'Name')}}!";
+
+            Handlebars.RegisterHelper("concat", (writer, context, args) =>
+            {
+                writer.WriteSafeString(string.Concat(args));
+            });
+
+            using (var reader = new StringReader("world"))
+            {
+                var partial = Handlebars.Compile(reader);
+                Handlebars.RegisterTemplate("partialName", partial);
+            }
+
+            var template = Handlebars.Compile(source);
+            var data = new { };
+            var result = template(data);
+            Assert.AreEqual("Hello, world!", result);
+        }
+
+        [Test]
         public void DynamicPartialWithContext()
         {
             var source = "Hello, {{> (lookup name) context }}!";

--- a/source/Handlebars/Compiler/ExpressionBuilder.cs
+++ b/source/Handlebars/Compiler/ExpressionBuilder.cs
@@ -26,8 +26,8 @@ namespace HandlebarsDotNet.Compiler
             tokens = HelperConverter.Convert(tokens, _configuration);
             tokens = HashParametersConverter.Convert(tokens);
             tokens = PathConverter.Convert(tokens);
-            tokens = PartialConverter.Convert(tokens);
             tokens = SubExpressionConverter.Convert(tokens);
+            tokens = PartialConverter.Convert(tokens);
             tokens = HelperArgumentAccumulator.Accumulate(tokens);
             tokens = ExpressionScopeConverter.Convert(tokens);
             tokens = BlockAccumulator.Accumulate(tokens, _configuration);

--- a/source/Handlebars/Compiler/Lexer/Converter/PartialConverter.cs
+++ b/source/Handlebars/Compiler/Lexer/Converter/PartialConverter.cs
@@ -25,20 +25,32 @@ namespace HandlebarsDotNet.Compiler
                 var partialToken = item as PartialToken;
                 if (partialToken != null)
                 {
-                    var partialName = partialToken.Value.Substring(1).Trim('"');
                     var arguments = AccumulateArguments(enumerator);
                     if (arguments.Count == 0)
                     {
+                        throw new HandlebarsCompilerException("A partial must have a name");
+                    }
+
+                    var partialName = arguments[0];
+
+                    if (partialName is PathExpression)
+                    {
+                        partialName = Expression.Constant(((PathExpression)partialName).Path);
+                    }
+
+                    if (arguments.Count == 1)
+                    {
                         yield return HandlebarsExpression.Partial(partialName);
                     }
-                    else if (arguments.Count == 1)
+                    else if (arguments.Count == 2)
                     {
-                        yield return HandlebarsExpression.Partial(partialName, arguments[0]);
+                        yield return HandlebarsExpression.Partial(partialName, arguments[1]);
                     }
                     else
                     {
-                        throw new HandlebarsCompilerException(string.Format("Partial {0} can only accept 0 or 1 arguments", partialName));
+                        throw new HandlebarsCompilerException("A partial can only accept 0 or 1 arguments");
                     }
+
                     yield return enumerator.Current;
                 }
                 else

--- a/source/Handlebars/Compiler/Lexer/Parsers/PartialParser.cs
+++ b/source/Handlebars/Compiler/Lexer/Parsers/PartialParser.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.IO;
-using System.Text;
+﻿using System.IO;
 
 namespace HandlebarsDotNet.Compiler.Lexer
 {
@@ -11,39 +9,9 @@ namespace HandlebarsDotNet.Compiler.Lexer
             PartialToken token = null;
             if ((char)reader.Peek() == '>')
             {
-                var buffer = AccumulatePartial(reader);
-                token = Token.Partial(buffer);
+                token = Token.Partial();
             }
             return token;
-        }
-
-        private string AccumulatePartial(TextReader reader)
-        {
-            StringBuilder buffer = new StringBuilder();
-            buffer.Append(">");
-            do
-            {
-                reader.Read();
-            }
-            while(char.IsWhiteSpace((char)reader.Peek()));
-            while(true)
-            {
-                var peek = (char)reader.Peek();
-                if (peek == '}' || peek == '~' || char.IsWhiteSpace(peek))
-                {
-                    break;
-                }
-                var node = reader.Read();
-                if (node == -1)
-                {
-                    throw new InvalidOperationException("Reached end of template before the expression was closed.");
-                }
-                else
-                {
-                    buffer.Append((char)node);
-                }
-            }
-            return buffer.ToString();
         }
     }
 }

--- a/source/Handlebars/Compiler/Lexer/Tokenizer.cs
+++ b/source/Handlebars/Compiler/Lexer/Tokenizer.cs
@@ -87,20 +87,19 @@ namespace HandlebarsDotNet.Compiler.Lexer
                         yield return Token.EndExpression(escaped, trimWhitespace);
                         inExpression = false;
                     }
+                    else if ((char)node == ')')
+                    {
+                        node = source.Read();
+                        yield return Token.EndSubExpression();
+                    }
                     else if (char.IsWhiteSpace((char)node) || char.IsWhiteSpace((char)source.Peek()))
                     {
                         node = source.Read();
-                        continue;
                     }
                     else if ((char)node == '~')
                     {
                         node = source.Read();
                         trimWhitespace = true;
-                    }
-                    else if ((char)node == ')')
-                    {
-                        node = source.Read();
-                        yield return Token.EndSubExpression();
                     }
                     else
                     {

--- a/source/Handlebars/Compiler/Lexer/Tokens/PartialToken.cs
+++ b/source/Handlebars/Compiler/Lexer/Tokens/PartialToken.cs
@@ -1,16 +1,7 @@
-﻿using System;
-
-namespace HandlebarsDotNet.Compiler.Lexer
+﻿namespace HandlebarsDotNet.Compiler.Lexer
 {
     internal class PartialToken : Token
     {
-        private readonly string _partialName;
-
-        public PartialToken(string partialName)
-        {
-            _partialName = partialName;
-        }
-
         public override TokenType Type
         {
             get { return TokenType.Partial; }
@@ -18,12 +9,12 @@ namespace HandlebarsDotNet.Compiler.Lexer
 
         public override string Value
         {
-            get { return _partialName; }
+            get { return ">"; }
         }
 
         public override string ToString()
         {
-            return this.Value;
+            return Value;
         }
     }
 }

--- a/source/Handlebars/Compiler/Lexer/Tokens/Token.cs
+++ b/source/Handlebars/Compiler/Lexer/Tokens/Token.cs
@@ -38,9 +38,9 @@ namespace HandlebarsDotNet.Compiler.Lexer
             return new CommentToken(comment);
         }
 
-        public static PartialToken Partial(string partialName)
+        public static PartialToken Partial()
         {
-            return new PartialToken(partialName);
+            return new PartialToken();
         }
 
         public static LayoutToken Layout(string layout)

--- a/source/Handlebars/Compiler/Structure/HandlebarsExpression.cs
+++ b/source/Handlebars/Compiler/Structure/HandlebarsExpression.cs
@@ -84,12 +84,12 @@ namespace HandlebarsDotNet.Compiler
             return new DeferredSectionExpression(path, body, evalMode);
         }
 
-        public static PartialExpression Partial(string partialName)
+        public static PartialExpression Partial(Expression partialName)
         {
             return Partial(partialName, null);
         }
 
-        public static PartialExpression Partial(string partialName, Expression argument)
+        public static PartialExpression Partial(Expression partialName, Expression argument)
         {
             return new PartialExpression(partialName, argument);
         }

--- a/source/Handlebars/Compiler/Structure/PartialExpression.cs
+++ b/source/Handlebars/Compiler/Structure/PartialExpression.cs
@@ -6,10 +6,10 @@ namespace HandlebarsDotNet.Compiler
 {
     internal class PartialExpression : HandlebarsExpression
     {
-        private readonly string _partialName;
+        private readonly Expression _partialName;
         private readonly Expression _argument;
 
-        public PartialExpression(string partialName, Expression argument)
+        public PartialExpression(Expression partialName, Expression argument)
         {
             _partialName = partialName;
             _argument = argument;
@@ -25,7 +25,7 @@ namespace HandlebarsDotNet.Compiler
             get { return typeof(void); }
         }
 
-        public string PartialName
+        public Expression PartialName
         {
             get { return _partialName; }
         }

--- a/source/Handlebars/Compiler/Translation/Expression/PartialBinder.cs
+++ b/source/Handlebars/Compiler/Translation/Expression/PartialBinder.cs
@@ -39,7 +39,7 @@ namespace HandlebarsDotNet.Compiler
             }
             return Expression.Call(
                 new Action<string, BindingContext, HandlebarsConfiguration>(InvokePartial).Method,
-                pex.PartialName,
+                Expression.Convert(pex.PartialName, typeof(string)),
                 bindingContext,
                 Expression.Constant(CompilationContext.Configuration));
         }

--- a/source/Handlebars/Compiler/Translation/Expression/PartialBinder.cs
+++ b/source/Handlebars/Compiler/Translation/Expression/PartialBinder.cs
@@ -39,7 +39,7 @@ namespace HandlebarsDotNet.Compiler
             }
             return Expression.Call(
                 new Action<string, BindingContext, HandlebarsConfiguration>(InvokePartial).Method,
-                Expression.Constant(pex.PartialName),
+                pex.PartialName,
                 bindingContext,
                 Expression.Constant(CompilationContext.Configuration));
         }


### PR DESCRIPTION
The change to `Tokenizer.cs` was to move the sub-expression end token higher as this seemed to get skipped when arguments were added to the sub-expression.