### PR TITLE
support else in #with

### DIFF
--- a/source/Handlebars.Test/BasicIntegrationTests.cs
+++ b/source/Handlebars.Test/BasicIntegrationTests.cs
@@ -180,6 +180,17 @@ namespace HandlebarsDotNet.Test
         }
 
         [Test]
+        public void BasicWithInversion()
+        {
+            var source = "Hello, {{#with person}} my good friend{{else}}nevermind{{/with}}";
+            var template = Handlebars.Compile(source);
+
+			Assert.AreEqual("Hello, nevermind", template(new {}));
+			Assert.AreEqual("Hello, nevermind", template(new {person = false}));
+			Assert.AreEqual("Hello, nevermind", template(new {person = new string[] {}}));
+        }
+
+        [Test]
         public void BasicEncoding()
         {
             var source = "Hello, {{name}}!";

--- a/source/Handlebars/BuiltinHelpers.cs
+++ b/source/Handlebars/BuiltinHelpers.cs
@@ -14,7 +14,15 @@ namespace HandlebarsDotNet
             {
                 throw new HandlebarsException("{{with}} helper must have exactly one argument"); 
             }
-            options.Template(output, arguments[0]);
+
+            if (HandlebarsUtils.IsTruthyOrNonEmpty(arguments[0]))
+            {
+                options.Template(output, arguments[0]);
+            }
+            else
+            {
+                options.Inverse(output, context);
+            }
         }
 
         public static IEnumerable<KeyValuePair<string, HandlebarsHelper>> Helpers


### PR DESCRIPTION
It is now possible to use {{else}} within {{#with}} block, similar to handlebars.js

    {{#with obj}}
      {{objProperty}}
    {{else}}
      inversion
    {{/with}}
