### PR TITLE
Fix whitespace bug with dictionary support

### DIFF
--- a/source/Handlebars/Compiler/Lexer/Parsers/WordParser.cs
+++ b/source/Handlebars/Compiler/Lexer/Parsers/WordParser.cs
@@ -7,7 +7,7 @@ namespace HandlebarsDotNet.Compiler.Lexer
 {
     internal class WordParser : Parser
     {
-        private const string validWordStartCharacters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_$.@";
+        private const string validWordStartCharacters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_$.@[]";
 
         public override Token Parse(TextReader reader)
         {
@@ -45,7 +45,7 @@ namespace HandlebarsDotNet.Compiler.Lexer
                 {
                     var peek = (char)reader.Peek();
 
-                    if (peek == '}' || peek == '~' || peek == ')' || char.IsWhiteSpace(peek))
+                    if (peek == '}' || peek == '~' || peek == ')' || (char.IsWhiteSpace(peek) && !buffer.ToString().Contains("[")))
                     {
                         break;
                     }
@@ -65,7 +65,8 @@ namespace HandlebarsDotNet.Compiler.Lexer
 
                 buffer.Append((char)node);
             }
-            return buffer.ToString();
+
+            return buffer.ToString().Trim();
         }
     }
 }

--- a/source/Handlebars/Compiler/Lexer/Parsers/WordParser.cs
+++ b/source/Handlebars/Compiler/Lexer/Parsers/WordParser.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.IO;
-using System.Linq;
 using System.Text;
 
 namespace HandlebarsDotNet.Compiler.Lexer
@@ -64,6 +63,11 @@ namespace HandlebarsDotNet.Compiler.Lexer
                 }
 
                 buffer.Append((char)node);
+            }
+
+            if (buffer.ToString().Contains("[") && !buffer.ToString().Contains("]"))
+            {
+                throw new HandlebarsCompilerException("Expression is missing a closing ].");
             }
 
             return buffer.ToString().Trim();


### PR DESCRIPTION
Fixes some whitespace issues with dictionary support. The following now work:

```handlebars
{{ [expression] }}
{{[expression]}}

{{ parent.[expression] }}
{{parent.[other expression]}}
```