### PR TITLE
use _configuration for locks instead of Handlebars type

### DIFF
--- a/source/Handlebars/HandlebarsEnvironment.cs
+++ b/source/Handlebars/HandlebarsEnvironment.cs
@@ -70,7 +70,7 @@ namespace HandlebarsDotNet
 
             public void RegisterTemplate(string templateName, Action<TextWriter, object> template)
             {
-                lock (typeof(Handlebars))
+                lock (_configuration)
                 {
                     _configuration.RegisteredTemplates.AddOrUpdate(templateName, template);
                 }
@@ -78,7 +78,7 @@ namespace HandlebarsDotNet
 
             public void RegisterHelper(string helperName, HandlebarsHelper helperFunction)
             {
-                lock (typeof(Handlebars))
+                lock (_configuration)
                 {
                     _configuration.Helpers.AddOrUpdate(helperName, helperFunction);
                 }
@@ -86,7 +86,7 @@ namespace HandlebarsDotNet
 
             public void RegisterHelper(string helperName, HandlebarsBlockHelper helperFunction)
             {
-                lock (typeof(Handlebars))
+                lock (_configuration)
                 {
                     _configuration.BlockHelpers.AddOrUpdate(helperName, helperFunction);
                 }


### PR DESCRIPTION
As mentioned in https://github.com/rexm/Handlebars.Net/issues/131 I went for reusing _configuration for locking instead of creating a separate lock variable, because _configuration is used within those locks and probably two instances with the same underlying configuration shouldn't interfere between each other.