### PR TITLE
Allow partials with hash parameters to fallback to parent context

### DIFF
--- a/source/Handlebars.Test/PartialTests.cs
+++ b/source/Handlebars.Test/PartialTests.cs
@@ -309,6 +309,58 @@ namespace HandlebarsDotNet.Test
             var result = template(data);
             Assert.AreEqual("Hello, Marc!", result);
         }
+
+        [Test]
+        public void BasicPartialWithStringParametersAndImplicitContext()
+        {
+            string source = "Hello, {{>person lastName='Smith'}}!";
+
+            var template = Handlebars.Compile(source);
+
+            var data = new
+            {
+                firstName = "Marc",
+                lastName = "Jones"
+            };
+
+            var partialSource = "{{firstName}} {{lastName}}";
+            using (var reader = new StringReader(partialSource))
+            {
+                var partialTemplate = Handlebars.Compile(reader);
+                Handlebars.RegisterTemplate("person", partialTemplate);
+            }
+
+            var result = template(data);
+            Assert.AreEqual("Hello, Marc Smith!", result);
+        }
+
+        [Test]
+        public void BasicPartialWithIncompleteChildContextDoesNotFallback()
+        {
+            string source = "Hello, {{>person leadDev}}!";
+
+            var template = Handlebars.Compile(source);
+
+            var data = new
+            {
+                firstName = "Pete",
+                lastName = "Jones",
+                leadDev = new
+                {
+                    firstName = "Marc"
+                }
+            };
+
+            var partialSource = "{{firstName}} {{lastName}}";
+            using (var reader = new StringReader(partialSource))
+            {
+                var partialTemplate = Handlebars.Compile(reader);
+                Handlebars.RegisterTemplate("person", partialTemplate);
+            }
+
+            var result = template(data);
+            Assert.AreEqual("Hello, Marc !", result);
+        }
     }
 }
 

--- a/source/Handlebars/Compiler/Translation/Expression/HashParameterDictionary.cs
+++ b/source/Handlebars/Compiler/Translation/Expression/HashParameterDictionary.cs
@@ -1,0 +1,6 @@
+using System.Collections.Generic;
+
+namespace HandlebarsDotNet.Compiler
+{
+    public class HashParameterDictionary : Dictionary<string, object> { }
+}

--- a/source/Handlebars/Compiler/Translation/Expression/PathBinder.cs
+++ b/source/Handlebars/Compiler/Translation/Expression/PathBinder.cs
@@ -163,7 +163,7 @@ namespace HandlebarsDotNet.Compiler
                         {
                             if (fallbackToParent && context.ParentContext != null)
                             {
-                                instance = ResolveValue(context.ParentContext, context.ParentContext.Value, memberName);
+                                instance = this.ResolveValue(context.ParentContext, context.ParentContext.Value, memberName);
 
                                 if (instance is UndefinedBindingResult)
                                 {

--- a/source/Handlebars/Compiler/Translation/Expression/PathBinder.cs
+++ b/source/Handlebars/Compiler/Translation/Expression/PathBinder.cs
@@ -117,7 +117,7 @@ namespace HandlebarsDotNet.Compiler
 
         private object ResolveParameters(BindingContext context, HashParametersExpression hpex)
         {
-            var parameters = new Dictionary<string, object>();
+            var parameters = new HashParameterDictionary();
 
             foreach (var parameter in hpex.Parameters)
             {
@@ -140,6 +140,8 @@ namespace HandlebarsDotNet.Compiler
         private object ResolvePath(BindingContext context, string path)
         {
             var instance = context.Value;
+            var fallbackToParent = instance is HashParameterDictionary;
+
             foreach (var segment in path.Split('/'))
             {
                 if (segment == "..")
@@ -156,9 +158,22 @@ namespace HandlebarsDotNet.Compiler
                     foreach (var memberName in segment.Split('.'))
                     {
                         instance = this.ResolveValue(context, instance, memberName);
+
                         if (instance is UndefinedBindingResult)
                         {
-                            break;
+                            if (fallbackToParent && context.ParentContext != null)
+                            {
+                                instance = ResolveValue(context.ParentContext, context.ParentContext.Value, memberName);
+
+                                if (instance is UndefinedBindingResult)
+                                {
+                                    break;
+                                }
+                            }
+                            else
+                            {
+                                break;
+                            }
                         }
                     }
                 }

--- a/source/Handlebars/Handlebars.csproj
+++ b/source/Handlebars/Handlebars.csproj
@@ -38,6 +38,7 @@
     <Compile Include="Compiler\CompilationContext.cs" />
     <Compile Include="Compiler\Structure\CommentExpression.cs" />
     <Compile Include="Compiler\Translation\Expression\CommentVisitor.cs" />
+    <Compile Include="Compiler\Translation\Expression\HashParameterDictionary.cs" />
     <Compile Include="HtmlEncoder.cs" />
     <Compile Include="Compiler\ExpressionBuilder.cs" />
     <Compile Include="Compiler\Lexer\Converter\HashParametersConverter.cs" />


### PR DESCRIPTION
This is a potential fix for #141 for you to look at.

It's simple but not amazingly elegant. It involves a new class to represent a hash parameter dictionary to prevent any false positives, then allowing `PathBinder.ResolvePath` to fallback to the parent context if hash parameters are used as the current context.

I have also added a test to make sure that when a child context with an incomplete scope is used it does not fallback to the parent context, to make sure we still match current handlebars behaviour.