### PR TITLE
Fall back to parent context if value not found in partial parameters

### DIFF
--- a/source/Handlebars.Test/PartialTests.cs
+++ b/source/Handlebars.Test/PartialTests.cs
@@ -54,7 +54,35 @@ namespace HandlebarsDotNet.Test
             Assert.AreEqual("Hello, Marc!", result);
         }
 
-        [Test]
+		[Test]
+		public void BasicPartialWithIncompleteContextIgnoringParentContext()
+		{
+			string source = "Hello, {{>person leadDev}}!";
+
+			var template = Handlebars.Compile(source);
+
+			var data = new
+			{
+				name = "Michael",
+				last = "Williams",
+				leadDev = new
+				{
+					name = "Marc"
+				}
+			};
+
+			var partialSource = "{{name}} {{last}}";
+			using (var reader = new StringReader(partialSource))
+			{
+				var partialTemplate = Handlebars.Compile(reader);
+				Handlebars.RegisterTemplate("person", partialTemplate);
+			}
+
+			var result = template(data);
+			Assert.AreEqual("Hello, Marc !", result);
+		}
+
+		[Test]
         public void BasicPartialWithStringParameter()
         {
             string source = "Hello, {{>person first='Pete'}}!";
@@ -166,7 +194,30 @@ namespace HandlebarsDotNet.Test
             Assert.AreEqual("Hello, 1 True!", result);
         }
 
-        [Test]
+		[Test]
+		public void BasicPartialWithStringParametersAndImplicitContext()
+		{
+			string source = "Hello, {{>person last='Smith'}}!";
+
+			var template = Handlebars.Compile(source);
+
+			var data = new
+			{
+				name = "Marc"
+			};
+
+			var partialSource = "{{name}} {{last}}";
+			using (var reader = new StringReader(partialSource))
+			{
+				var partialTemplate = Handlebars.Compile(reader);
+				Handlebars.RegisterTemplate("person", partialTemplate);
+			}
+
+			var result = template(data);
+			Assert.AreEqual("Hello, Marc Smith!", result);
+		}
+
+		[Test]
         public void BasicPartialWithStringParameterIncludingExpressionChars()
         {
             string source = "Hello, {{>person first='Pe ({~te~}) '}}!";

--- a/source/Handlebars/Compiler/Structure/BindingContext.cs
+++ b/source/Handlebars/Compiler/Structure/BindingContext.cs
@@ -1,4 +1,6 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.Dynamic;
+using System.IO;
 using System.Reflection;
 
 namespace HandlebarsDotNet.Compiler

--- a/source/Handlebars/Compiler/Translation/Expression/PartialBinder.cs
+++ b/source/Handlebars/Compiler/Translation/Expression/PartialBinder.cs
@@ -65,15 +65,14 @@ namespace HandlebarsDotNet.Compiler
 
 	    private static object MergeContextValues(object contextValue, object hashParams)
 		{
-			dynamic merged = new ExpandoObject();
-			var valueDict = merged as IDictionary<string, object>;
-			valueDict = Upsert(contextValue, valueDict);
-			valueDict = Upsert(hashParams, valueDict);
+			IDictionary<string, object> valueDict = new Dictionary<string, object>();
+			valueDict = MergeInObject(hashParams, valueDict);
+			valueDict = MergeInObject(contextValue, valueDict);
 
 			return valueDict;
 	    }
 
-	    private static IDictionary<string, object> Upsert(object contextValue, IDictionary<string, object> valueDict)
+	    private static IDictionary<string, object> MergeInObject(object contextValue, IDictionary<string, object> valueDict)
 	    {
 		    if (contextValue == null)
 		    {


### PR DESCRIPTION
In cases when a partial is called with literal arguments, but a variable within the partial is not part of those literal arguments, the partial should attempt to resolve the value from the parent context.

Fixes Issue #141.
