### PR TITLE
Bug in PartialBinder.cs when using FileSystem object

### DIFF
--- a/source/Handlebars/Compiler/Translation/Expression/PartialBinder.cs
+++ b/source/Handlebars/Compiler/Translation/Expression/PartialBinder.cs
@@ -97,6 +97,11 @@ namespace HandlebarsDotNet.Compiler
                             writer.Write(compiled(o));
                         });
                     }
+                    else
+                    {
+                        // Failed to find partial in filesystem
+                        return false;
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
The current code doesn't catch partials that do not exist in the file system and code returns "Key not found in dictionary".  Returning false at proposed edits will return a proper "Referenced partial name <name> could not be resolved" when not found in filesystem.

This is based on current implementation of abstract ViewEngineFileSystem where
FileSystem.Closest is set to return null when file not found.