### PR TITLE
Exposing Internal Compiler and Environment

### DIFF
--- a/source/Handlebars/Compiler/IHandlebarsCompiler.cs
+++ b/source/Handlebars/Compiler/IHandlebarsCompiler.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using HandlebarsDotNet.Compiler.Lexer;
+
+namespace HandlebarsDotNet.Compiler {
+	public interface IHandlebarsCompiler {
+		IEnumerable<IToken> Tokenize( TextReader source );
+		IEnumerable<Expression> ExpressionBuilder( IEnumerable<IToken> tokens );
+		Action<TextWriter, object> FunctionBuilder( IEnumerable<Expression> expressions, string templatePath = null );
+		Action<TextWriter, object> Compile( TextReader source );
+		Action<TextWriter, object> CompileView( string templatePath );
+
+	}
+}

--- a/source/Handlebars/Compiler/Lexer/Tokens/IToken.cs
+++ b/source/Handlebars/Compiler/Lexer/Tokens/IToken.cs
@@ -1,0 +1,9 @@
+﻿
+
+namespace HandlebarsDotNet.Compiler.Lexer
+{
+	public interface IToken {
+		TokenType Type { get; }
+		string Value { get; }
+	}
+}

--- a/source/Handlebars/Compiler/Lexer/Tokens/Token.cs
+++ b/source/Handlebars/Compiler/Lexer/Tokens/Token.cs
@@ -2,7 +2,7 @@
 
 namespace HandlebarsDotNet.Compiler.Lexer
 {
-    internal abstract class Token
+    internal abstract class Token : IToken
     {
         public abstract TokenType Type { get; }
 

--- a/source/Handlebars/Compiler/Lexer/Tokens/TokenType.cs
+++ b/source/Handlebars/Compiler/Lexer/Tokens/TokenType.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace HandlebarsDotNet.Compiler.Lexer
 {
-    internal enum TokenType
+    public enum TokenType
     {
         Static = 0,
         StartExpression = 1,

--- a/source/Handlebars/Handlebars.cs
+++ b/source/Handlebars/Handlebars.cs
@@ -6,7 +6,7 @@ namespace HandlebarsDotNet
     public delegate void HandlebarsHelper(TextWriter output, dynamic context, params object[] arguments);
     public delegate void HandlebarsBlockHelper(TextWriter output, HelperOptions options, dynamic context, params object[] arguments);
 
-    public sealed class Handlebars
+    public sealed partial class Handlebars
     {
         // Lazy-load Handlebars environment to ensure thread safety.  See Jon Skeet's excellent article on this for more info. http://csharpindepth.com/Articles/General/Singleton.aspx
         private static readonly Lazy<IHandlebars> lazy = new Lazy<IHandlebars>(() => new HandlebarsEnvironment(new HandlebarsConfiguration()));

--- a/source/Handlebars/Handlebars.cs
+++ b/source/Handlebars/Handlebars.cs
@@ -6,7 +6,7 @@ namespace HandlebarsDotNet
     public delegate void HandlebarsHelper(TextWriter output, dynamic context, params object[] arguments);
     public delegate void HandlebarsBlockHelper(TextWriter output, HelperOptions options, dynamic context, params object[] arguments);
 
-    public sealed partial class Handlebars
+    public sealed class Handlebars
     {
         // Lazy-load Handlebars environment to ensure thread safety.  See Jon Skeet's excellent article on this for more info. http://csharpindepth.com/Articles/General/Singleton.aspx
         private static readonly Lazy<IHandlebars> lazy = new Lazy<IHandlebars>(() => new HandlebarsEnvironment(new HandlebarsConfiguration()));

--- a/source/Handlebars/Handlebars.csproj
+++ b/source/Handlebars/Handlebars.csproj
@@ -36,6 +36,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Compiler\CompilationContext.cs" />
+    <Compile Include="Compiler\IHandlebarsCompiler.cs" />
+    <Compile Include="Compiler\Lexer\Tokens\IToken.cs" />
     <Compile Include="Compiler\Structure\CommentExpression.cs" />
     <Compile Include="Compiler\Translation\Expression\CommentVisitor.cs" />
     <Compile Include="Compiler\Translation\Expression\HashParameterDictionary.cs" />

--- a/source/Handlebars/HandlebarsEnvironment.cs
+++ b/source/Handlebars/HandlebarsEnvironment.cs
@@ -5,6 +5,8 @@ using HandlebarsDotNet.Compiler;
 
 namespace HandlebarsDotNet
 {
+    public partial class Handlebars
+    {
         public class HandlebarsEnvironment : IHandlebars
         {
             private readonly HandlebarsConfiguration _configuration;
@@ -108,5 +110,5 @@ namespace HandlebarsDotNet
                 }
             }
         }
- 
+    }
 }

--- a/source/Handlebars/HandlebarsEnvironment.cs
+++ b/source/Handlebars/HandlebarsEnvironment.cs
@@ -5,12 +5,10 @@ using HandlebarsDotNet.Compiler;
 
 namespace HandlebarsDotNet
 {
-    public partial class Handlebars
-    {
-        private class HandlebarsEnvironment : IHandlebars
+        public class HandlebarsEnvironment : IHandlebars
         {
             private readonly HandlebarsConfiguration _configuration;
-            private readonly HandlebarsCompiler _compiler;
+            private readonly IHandlebarsCompiler _compiler;
 
             public HandlebarsEnvironment(HandlebarsConfiguration configuration)
             {
@@ -46,7 +44,13 @@ namespace HandlebarsDotNet
                 }
             }
 
-            public Action<TextWriter, object> Compile(TextReader template)
+			public IHandlebarsCompiler Compiler {
+				get {
+					return this._compiler;
+				}
+			}
+
+			public Action<TextWriter, object> Compile(TextReader template)
             {
                 return _compiler.Compile(template);
             }
@@ -104,5 +108,5 @@ namespace HandlebarsDotNet
                 }
             }
         }
-    }
+ 
 }

--- a/source/Handlebars/IHandlebars.cs
+++ b/source/Handlebars/IHandlebars.cs
@@ -15,7 +15,9 @@ namespace HandlebarsDotNet
 
         HandlebarsConfiguration Configuration { get; }
 
-        void RegisterTemplate(string templateName, Action<TextWriter, object> template);
+		IHandlebarsCompiler Compiler { get; }
+
+		void RegisterTemplate(string templateName, Action<TextWriter, object> template);
 
         void RegisterHelper(string helperName, HandlebarsHelper helperFunction);
 


### PR DESCRIPTION
I needed the ability to expand on the base compiler to give a more tuned ViewEngine object for MVC .net.  I am testing my code and did not want to rewrite your compile engine.  Basically, this is a start on the ability to build custom compile engines.  I think the CompileView looks like a pretty custom compile engine and think it should be moved into an extension of the base compile class.  Anyway, that is a tangled web and this at least exposes the first layer of the compile engine to expand off of.

The changes will:

- Expose HandlebarsEnvironment to the public.  Inheritable and possible build your own with IHandlebars.
- Expose Token to the public through IToken interface.
- Expose HandlebarsCompiler to the public through IHandlebarsCompiler interface.
- Expose 3 new functions in HandlebarsCompiler that make up the primary method of compiling.

The three new function in HandlebarsCompiler:

1. IEnumerable<IToken> Tokenize( TextReader source )
2. IEnumerable<Expression> ExpressionBuilder( IEnumerable<IToken> tokens )
3. Action<TextWriter, object> FunctionBuilder( IEnumerable<Expression> expressions, string templatePath = null )

