### PR TITLE
fixes issue #143

### DIFF
--- a/source/Handlebars.Test/BasicIntegrationTests.cs
+++ b/source/Handlebars.Test/BasicIntegrationTests.cs
@@ -21,6 +21,43 @@ namespace HandlebarsDotNet.Test
             Assert.AreEqual("Hello, Handlebars.Net!", result);
         }
 
+		[Test]
+        public void BasicPathUnresolvedBindingFormatter()
+        {
+            var source = "Hello, {{foo}}!";
+
+	        var config = new HandlebarsConfiguration
+	        {
+		        UnresolvedBindingFormatter = "('{0}' is undefined)"
+	        };
+	        var handlebars = Handlebars.Create( config );
+
+            var template = handlebars.Compile(source);
+            var data = new {
+                name = "Handlebars.Net"
+            };
+            var result = template(data);
+            Assert.AreEqual("Hello, ('foo' is undefined)!", result);
+        }
+
+		[Test]
+        public void BasicPathThrowOnUnresolvedBindingExpression()
+        {
+            var source = "Hello, {{foo}}!";
+
+            var config = new HandlebarsConfiguration
+	        {
+		        ThrowOnUnresolvedBindingExpression = true
+	        };
+	        var handlebars = Handlebars.Create( config );
+	        var template = handlebars.Compile( source );
+
+            var data = new {
+                name = "Handlebars.Net"
+            };
+	        Assert.Throws<Exception>( () => template( data ) );
+        }
+
         [Test]
         public void BasicPathWhiteSpace()
         {

--- a/source/Handlebars/Compiler/Structure/UndefinedBindingResult.cs
+++ b/source/Handlebars/Compiler/Structure/UndefinedBindingResult.cs
@@ -6,13 +6,19 @@ namespace HandlebarsDotNet.Compiler
     [DebuggerDisplay("undefined")]
     internal class UndefinedBindingResult
     {
-        public UndefinedBindingResult()
-        {
-        }
+	    public readonly string Value;
+	    private readonly HandlebarsConfiguration _configuration;
+
+	    public UndefinedBindingResult(string value, HandlebarsConfiguration configuration)
+	    {
+		    Value = value;
+		    _configuration = configuration;
+	    }
 
         public override string ToString()
         {
-            return string.Empty;
+	        var formatter = _configuration.UnresolvedBindingFormatter ?? string.Empty;
+	        return string.Format( formatter, Value );
         }
     }
 }

--- a/source/Handlebars/HandlebarsConfiguration.cs
+++ b/source/Handlebars/HandlebarsConfiguration.cs
@@ -19,12 +19,16 @@ namespace HandlebarsDotNet
 
         public ViewEngineFileSystem FileSystem { get; set; }
 
-        public HandlebarsConfiguration()
+	    public string UnresolvedBindingFormatter { get; set; }
+	    public bool ThrowOnUnresolvedBindingExpression { get; set; }
+
+	    public HandlebarsConfiguration()
         {
             this.Helpers = new Dictionary<string, HandlebarsHelper>(StringComparer.OrdinalIgnoreCase);
             this.BlockHelpers = new Dictionary<string, HandlebarsBlockHelper>(StringComparer.OrdinalIgnoreCase);
             this.RegisteredTemplates = new Dictionary<string, Action<TextWriter, object>>(StringComparer.OrdinalIgnoreCase);
             this.TextEncoder = new HtmlEncoder();
+	        this.ThrowOnUnresolvedBindingExpression = false;
         }
     }
 }


### PR DESCRIPTION
Added 2 properties to the HandlebarsConfiguration...

* UnresolvedBindingFormatter ( string ex. ('{0}' is undefined) )
* ThrowOnUnresolvedBindingExpression ( bool )

The UnresolvedBindingFormatter  will translate any undefined into whatever string you want to show in your ouput (if your not throwing an exception of course)

some uses....
ex. {{foo}} => ('foo' is undefined)
ex. {{foo}} => <span class='error'>{{foo}}</span>