### PR TITLE
Keep track of block/helper name in exceptions

### DIFF
--- a/source/Handlebars.Test/ExceptionTests.cs
+++ b/source/Handlebars.Test/ExceptionTests.cs
@@ -1,0 +1,15 @@
+﻿using NUnit.Framework;
+
+namespace HandlebarsDotNet.Test
+{
+    [TestFixture]
+    public class ExceptionTests
+    {
+        [Test]
+        [ExpectedException("HandlebarsDotNet.HandlebarsCompilerException", ExpectedMessage = "Reached end of template before block expression 'if' was closed")]
+        public void TestNonClosingBlockExpressionException()
+        {
+            Handlebars.Compile( "{{#if 0}}test" )( new { } );
+        }
+    }
+}

--- a/source/Handlebars.Test/Handlebars.Test.csproj
+++ b/source/Handlebars.Test/Handlebars.Test.csproj
@@ -67,6 +67,7 @@
     <Compile Include="ComplexIntegrationTests.cs" />
     <Compile Include="CustomConfigurationTests.cs" />
     <Compile Include="DynamicTests.cs" />
+    <Compile Include="ExceptionTests.cs" />
     <Compile Include="HelperTests.cs" />
     <Compile Include="TripleStashTests.cs" />
     <Compile Include="PartialTests.cs" />

--- a/source/Handlebars.sln
+++ b/source/Handlebars.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Handlebars", "Handlebars\Handlebars.csproj", "{A09CFF95-B671-48FE-96A8-D3CBDC110B75}"
 EndProject

--- a/source/Handlebars/Compiler/Lexer/Converter/BlockAccumulator.cs
+++ b/source/Handlebars/Compiler/Lexer/Converter/BlockAccumulator.cs
@@ -61,7 +61,8 @@ namespace HandlebarsDotNet.Compiler
                     context.HandleElement(item);
                 }
             }
-            throw new HandlebarsCompilerException("Reached end of template before block expression was closed");
+            throw new HandlebarsCompilerException(
+                $"Reached end of template before block expression '{context.Name}' was closed");
         }
 
         private Expression UnwrapStatement(Expression item)

--- a/source/Handlebars/Compiler/Lexer/Converter/BlockAccumulators/BlockAccumulatorContext.cs
+++ b/source/Handlebars/Compiler/Lexer/Converter/BlockAccumulators/BlockAccumulatorContext.cs
@@ -32,6 +32,24 @@ namespace HandlebarsDotNet.Compiler
             return context;
         }
 
+        public string Name
+        {
+            get
+            {
+                var type = GetType();
+                if (type == typeof(BlockHelperAccumulatorContext))
+                    return ((BlockHelperAccumulatorContext)this).HelperName;
+
+                if (type == typeof(ConditionalBlockAccumulatorContext))
+                    return ((ConditionalBlockAccumulatorContext)this).BlockName;
+
+                if (type == typeof(IteratorBlockAccumulatorContext))
+                    return ((IteratorBlockAccumulatorContext)this).BlockName;
+
+                return null;
+            }
+        }
+
         private static bool IsConditionalBlock(Expression item)
         {
             item = UnwrapStatement(item);

--- a/source/Handlebars/Compiler/Lexer/Converter/BlockAccumulators/BlockHelperAccumulatorContext.cs
+++ b/source/Handlebars/Compiler/Lexer/Converter/BlockAccumulators/BlockHelperAccumulatorContext.cs
@@ -19,6 +19,8 @@ namespace HandlebarsDotNet.Compiler
             _startingNode = (HelperExpression)startingNode;
         }
 
+        public string HelperName => _startingNode.HelperName;
+
         public override void HandleElement(Expression item)
         {
             if (IsInversionBlock(item))

--- a/source/Handlebars/Compiler/Lexer/Converter/BlockAccumulators/ConditionalBlockAccumulatorContext.cs
+++ b/source/Handlebars/Compiler/Lexer/Converter/BlockAccumulators/ConditionalBlockAccumulatorContext.cs
@@ -7,25 +7,24 @@ namespace HandlebarsDotNet.Compiler
 {
     internal class ConditionalBlockAccumulatorContext : BlockAccumulatorContext
     {
-        private List<ConditionalExpression> _conditionalBlock = new List<ConditionalExpression>();
+        private readonly List<ConditionalExpression> _conditionalBlock = new List<ConditionalExpression>();
         private Expression _currentCondition;
         private List<Expression> _bodyBuffer = new List<Expression>();
-        private readonly bool _testType;
-        private readonly string _blockName;
+        public string BlockName { get; }
 
         public ConditionalBlockAccumulatorContext(Expression startingNode)
             : base(startingNode)
         {
             startingNode = UnwrapStatement(startingNode);
-            _blockName = ((HelperExpression)startingNode).HelperName.Replace("#", "");
-            if (new [] { "if", "unless" }.Contains(_blockName) == false)
+            BlockName = ((HelperExpression)startingNode).HelperName.Replace("#", "");
+            if (new [] { "if", "unless" }.Contains(BlockName) == false)
             {
                 throw new HandlebarsCompilerException(string.Format(
-                        "Tried to convert {0} expression to conditional block", _blockName));
+                        "Tried to convert {0} expression to conditional block", BlockName));
             }
-            _testType = _blockName == "if";
+            var testType = BlockName == "if";
             var argument = HandlebarsExpression.Boolish(((HelperExpression)startingNode).Arguments.Single());
-            _currentCondition = _testType ? (Expression)argument : Expression.Not(argument);
+            _currentCondition = testType ? (Expression)argument : Expression.Not(argument);
         }
 
         public override void HandleElement(Expression item)
@@ -107,7 +106,7 @@ namespace HandlebarsDotNet.Compiler
         private bool IsClosingNode(Expression item)
         {
             item = UnwrapStatement(item);
-            return item is PathExpression && ((PathExpression)item).Path == "/" + _blockName;
+            return item is PathExpression && ((PathExpression)item).Path == "/" + BlockName;
         }
 
         private static IEnumerable<Expression> UnwrapBlockExpression(IEnumerable<Expression> body)

--- a/source/Handlebars/Compiler/Lexer/Converter/BlockAccumulators/IteratorBlockAccumulatorContext.cs
+++ b/source/Handlebars/Compiler/Lexer/Converter/BlockAccumulators/IteratorBlockAccumulatorContext.cs
@@ -18,6 +18,8 @@ namespace HandlebarsDotNet.Compiler
             _startingNode = (HelperExpression)startingNode;
         }
 
+        public string BlockName => _startingNode.HelperName;
+
         public override void HandleElement(Expression item)
         {
             if (IsElseBlock(item))

--- a/source/Handlebars/Compiler/Translation/Expression/PartialBinder.cs
+++ b/source/Handlebars/Compiler/Translation/Expression/PartialBinder.cs
@@ -108,8 +108,19 @@ namespace HandlebarsDotNet.Compiler
                     return false;
                 }
             }
-            configuration.RegisteredTemplates[partialName](context.TextWriter, context);
-            return true;
+
+            try
+            {
+                configuration.RegisteredTemplates[partialName]( context.TextWriter, context );
+                return true;
+            }
+            catch ( Exception exception )
+            {
+                throw new HandlebarsRuntimeException(
+                    $"Runtime error while rendering partial '{partialName}', see inner exception for more information",
+                    exception );
+            }
+
         }
     }
 }


### PR DESCRIPTION
If an exception occurs at runtime, show helper/blockname in exception