### PR TITLE
Update to support .NetStandard 1.3

### DIFF
--- a/Handlebars.Net.nuspec
+++ b/Handlebars.Net.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Handlebars.Net</id>
-    <version>1.8.0</version>
+    <version>1.8.1</version>
     <title>Handlebars.Net</title>
     <authors>Rex Morgan</authors>
     <projectUrl>https://github.com/rexm/Handlebars.Net</projectUrl>
@@ -11,19 +11,27 @@
     <description>Blistering-fast Handlebars.js templates in your .NET application.</description>
     <summary>Blistering-fast Handlebars.js templates in your .NET application.</summary>
     <tags>handlebars mustache templating engine compiler</tags>
-    <releaseNotes>Now supports "dotnet core" / net standard 1.5! Also added support for inline partials. Also includes fixes for more complicated scenarios with hash parameters, and improved support for literals.</releaseNotes>
+    <releaseNotes>Now supports "dotnet core" net standard 1.3</releaseNotes>
     <dependencies>
       <group targetFramework="net45" />
-      <group targetFramework=".NETStandard1.5">
-        <dependency id="System.Dynamic.Runtime" version="4.0.11" />
-        <dependency id="System.Reflection.Extensions" version="4.0.1" />
-        <dependency id="Microsoft.CSharp" version="4.0.1" />
-        <dependency id="NETStandard.Library" version="1.6.0" />
+      <group targetFramework=".NETStandard1.3">
+        <dependency id="Microsoft.CSharp" version= "4.3.0"/>
+        <dependency id="System.Collections" version= "4.3.0"/>
+        <dependency id="System.Diagnostics.Debug" version= "4.3.0"/>
+        <dependency id="System.Dynamic.Runtime" version= "4.3.0"/>
+        <dependency id="System.Globalization" version= "4.3.0"/>
+        <dependency id="System.Linq" version= "4.3.0"/>
+        <dependency id="System.Reflection" version= "4.3.0"/>
+        <dependency id="System.Reflection.Extensions" version= "4.3.0"/>
+        <dependency id="System.Reflection.TypeExtensions" version= "4.3.0"/>
+        <dependency id="System.Runtime.Extensions" version= "4.3.0"/>
+        <dependency id="System.Text.RegularExpressions" version= "4.3.0"/>
+        <dependency id="System.Threading" version= "4.3.0"/>
       </group>
     </dependencies>
   </metadata>
   <files>
     <file src="source/Handlebars/bin/Release/Handlebars.dll" target="lib/portable-net45+sl5+wp8+win8/Handlebars.dll" />
-    <file src="source/Handlebars.NetStandard/bin/Release/netstandard1.5/Handlebars.dll" target="lib/netstandard1.5/Handlebars.dll" />
+    <file src="source/Handlebars.NetStandard/bin/Release/netstandard1.3/Handlebars.dll" target="lib/netstandard1.3/Handlebars.dll" />
   </files>
 </package>

--- a/source/Handlebars.NetStandard.Test/Handlebars.NetStandard.Test.xproj
+++ b/source/Handlebars.NetStandard.Test/Handlebars.NetStandard.Test.xproj
@@ -4,7 +4,6 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-
   <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>e672e2f7-9297-4a17-b022-6dd658b19c25</ProjectGuid>
@@ -13,9 +12,11 @@
     <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
   </PropertyGroup>
-
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/source/Handlebars.NetStandard.Test/project.json
+++ b/source/Handlebars.NetStandard.Test/project.json
@@ -1,37 +1,37 @@
 {
-  "version": "1.0.0-*",
-  "buildOptions": {
-    "emitEntryPoint": true,
-    "define": [ "netstandard" ],
-    "compile": {
-      "include": "../Handlebars.Test/**/*.cs",
-      "exclude": "../Handlebars.Test/**/CasparTests.cs"
+    "version": "1.0.0-*",
+    "buildOptions": {
+        "emitEntryPoint": true,
+        "define": [ "netstandard" ],
+        "compile": {
+            "include": "../Handlebars.Test/**/*.cs",
+            "exclude": "../Handlebars.Test/**/CasparTests.cs"
+        }
+    },
+
+    "testRunner": "nunit",
+
+    "dependencies": {
+        "Handlebars.NetStandard": { "target": "project" },
+        "Newtonsoft.Json": "9.0.1",
+        "dotnet-test-nunit": "3.4.0-beta-1",
+        "System.Dynamic.Runtime": "4.3.0"
+    },
+
+    "frameworks": {
+        "netcoreapp1.0": {
+            "imports": [
+                "portable-net45+win8"
+            ],
+            "dependencies": {
+                "Microsoft.NETCore.App": {
+                    "type": "platform",
+                    "version": "1.1.0"
+                },
+                "System.Collections": "4.3.0",
+                "System.Collections.NonGeneric": "4.3.0",
+                "NUnitLite": "3.4.1"
+            }
+        }
     }
-  },
-
-  "testRunner": "nunit",
-
-  "dependencies": {
-    "Handlebars.NetStandard": "1.0.0-*",
-    "Newtonsoft.Json": "9.0.1",
-    "dotnet-test-nunit": "3.4.0-beta-1",
-    "System.Dynamic.Runtime": "4.0.11"
-  },
-
-  "frameworks": {
-    "netcoreapp1.0": {
-      "imports": [
-        "portable-net45+win8"
-      ],
-      "dependencies": {
-        "Microsoft.NETCore.App": {
-          "type": "platform",
-          "version": "1.0.0"
-        },
-        "System.Collections": "4.0.11",
-        "System.Collections.NonGeneric": "4.0.1",
-        "NUnitLite": "3.4.1"
-      }
-    }
-  }
 }

--- a/source/Handlebars.NetStandard/project.json
+++ b/source/Handlebars.NetStandard/project.json
@@ -25,6 +25,15 @@
     },
 
     "frameworks": {
+        ".NETPortable,Version=v4.0,Profile=Profile24": {
+            "frameworkAssemblies": {
+                "mscorlib": "",
+                "System": "",
+                "System.Core": "",
+                "System.Net": "",
+                "Microsoft.CSharp": ""
+            }
+        },
         "net45": {
         },
         "netstandard1.3": {

--- a/source/Handlebars.NetStandard/project.json
+++ b/source/Handlebars.NetStandard/project.json
@@ -1,26 +1,50 @@
 ﻿{
-  "version": "1.0.0-*",
-  "title": "Handlebars",
-  "dependencies": {
-    "NETStandard.Library": "1.6.0"
-  },
-  "buildOptions": {
-    "outputName": "Handlebars",
-    "compile": {
-      "include": "../Handlebars/**/*.cs"
+    "version": "1.8.1",
+    "title": "Handlebars",
+    "description": "Blistering-fast Handlebars.js templates in your .NET application.",
+    "authors": [ "Rex Morgan", "Stef Heyenrath" ],
+
+    "packOptions": {
+        "summary": "Blistering-fast Handlebars.js templates in your .NET application.",
+        "tags": [ "handlebars", "mustache", "templating", "engine", "compiler" ],
+        "owners": [ "Rex Morgan" ],
+        "repository": {
+            "type": "git",
+            "url": "https://github.com/rexm/Handlebars.Net"
+        },
+        "projectUrl": "https://github.com/rexm/Handlebars.Net",
+        "iconUrl": "https://raw.githubusercontent.com/rexm/Handlebars.Net/master/hbnet-icon.png",
+        "releaseNotes": "Now supports net standard 1.3"
+    },
+
+    "buildOptions": {
+        "outputName": "Handlebars",
+        "compile": {
+            "include": "../Handlebars/**/*.cs"
+        }
+    },
+
+    "frameworks": {
+        "net45": {
+        },
+        "netstandard1.3": {
+            "buildOptions": {
+                "define": [ "netstandard" ]
+            },
+            "dependencies": {
+                "Microsoft.CSharp": "4.3.0",
+                "System.Collections": "4.3.0",
+                "System.Diagnostics.Debug": "4.3.0",
+                "System.Dynamic.Runtime": "4.3.0",
+                "System.Globalization": "4.3.0",
+                "System.Linq": "4.3.0",
+                "System.Reflection": "4.3.0",
+                "System.Reflection.Extensions": "4.3.0",
+                "System.Reflection.TypeExtensions": "4.3.0",
+                "System.Runtime.Extensions": "4.3.0",
+                "System.Text.RegularExpressions": "4.3.0",
+                "System.Threading": "4.3.0"
+            }
+        }
     }
-  },
-  "frameworks": {
-    "net451": {    },
-    "netstandard1.5": {
-      "buildOptions": {
-        "define": [ "netstandard" ]
-      },
-      "dependencies": {
-        "System.Dynamic.Runtime": "4.0.11",
-        "System.Reflection.Extensions": "4.0.1",
-        "Microsoft.CSharp": "4.0.1"
-      }
-    }
-  }
 }

--- a/source/Handlebars/BuiltinHelpers.cs
+++ b/source/Handlebars/BuiltinHelpers.cs
@@ -5,14 +5,14 @@ using System.Collections.Generic;
 
 namespace HandlebarsDotNet
 {
-	internal static class BuiltinHelpers
+    internal static class BuiltinHelpers
     {
         [Description("with")]
         public static void With(TextWriter output, HelperOptions options, dynamic context, params object[] arguments)
         {
             if (arguments.Length != 1)
             {
-                throw new HandlebarsException("{{with}} helper must have exactly one argument"); 
+                throw new HandlebarsException("{{with}} helper must have exactly one argument");
             }
 
             if (HandlebarsUtils.IsTruthyOrNonEmpty(arguments[0]))
@@ -44,27 +44,22 @@ namespace HandlebarsDotNet
         private static IEnumerable<KeyValuePair<string, T>> GetHelpers<T>()
         {
             var builtInHelpersType = typeof(BuiltinHelpers);
-#if netstandard
-            foreach (var method in builtInHelpersType.GetTypeInfo().GetMethods(BindingFlags.DeclaredOnly | BindingFlags.Static | BindingFlags.Public))
-
-#else
             foreach (var method in builtInHelpersType.GetMethods(BindingFlags.DeclaredOnly | BindingFlags.Static | BindingFlags.Public))
-#endif
             {
                 Delegate possibleDelegate;
-	            try
-	            {
+                try
+                {
 #if netstandard
                         possibleDelegate = method.CreateDelegate(typeof(T));
 #else
-                        possibleDelegate = Delegate.CreateDelegate(typeof(T), method); 
+                    possibleDelegate = Delegate.CreateDelegate(typeof(T), method);
 #endif
-	            }
-	            catch
-	            {
-		            possibleDelegate = null;
-	            }
-	            if (possibleDelegate != null)
+                }
+                catch
+                {
+                    possibleDelegate = null;
+                }
+                if (possibleDelegate != null)
                 {
 #if netstandard
                     yield return new KeyValuePair<string, T>(

--- a/source/Handlebars/Compiler/HandlebarsCompiler.cs
+++ b/source/Handlebars/Compiler/HandlebarsCompiler.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Dynamic;
 using System.IO;
 using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
 using System.Text;
 using HandlebarsDotNet.Compiler.Lexer;
@@ -19,7 +18,7 @@ namespace HandlebarsDotNet.Compiler
 
         public HandlebarsCompiler(HandlebarsConfiguration configuration)
         {
-            _configuration=configuration;
+            _configuration = configuration;
             _tokenizer = new Tokenizer(configuration);
             _expressionBuilder = new ExpressionBuilder(configuration);
             _functionBuilder = new FunctionBuilder(configuration);
@@ -62,7 +61,7 @@ namespace HandlebarsDotNet.Compiler
                     compiledView(innerWriter, vm);
                 }
                 var inner = sb.ToString();
-                compiledLayout(tw, new DynamicViewModel(new {body = inner}));
+                compiledLayout(tw, new DynamicViewModel(new { body = inner }));
             };
         }
 
@@ -79,15 +78,9 @@ namespace HandlebarsDotNet.Compiler
 
             public override IEnumerable<string> GetDynamicMemberNames()
             {
-#if netstandard
-                return _objects.Select(o => o.GetType())
-                   .SelectMany(t => t.GetTypeInfo().GetMembers(BindingFlags))
-                   .Select(m => m.Name);
-#else
                 return _objects.Select(o => o.GetType())
                     .SelectMany(t => t.GetMembers(BindingFlags))
                     .Select(m => m.Name);
-#endif
             }
 
             public override bool TryGetMember(GetMemberBinder binder, out object result)
@@ -95,13 +88,7 @@ namespace HandlebarsDotNet.Compiler
                 result = null;
                 foreach (var target in _objects)
                 {
-#if netstandard
-                    var member = target.GetType().GetTypeInfo()
-                        .GetMember(binder.Name, BindingFlags);
-#else
-                    var member = target.GetType()
-                        .GetMember(binder.Name, BindingFlags);
-#endif
+                    var member = target.GetType().GetMember(binder.Name, BindingFlags);
                     if (member.Length > 0)
                     {
                         if (member[0] is PropertyInfo)
@@ -122,6 +109,6 @@ namespace HandlebarsDotNet.Compiler
 
     }
 
- 
+
 }
 

--- a/source/Handlebars/Compiler/Structure/BindingContext.cs
+++ b/source/Handlebars/Compiler/Structure/BindingContext.cs
@@ -1,5 +1,4 @@
-﻿using System.IO;
-using System.Reflection;
+﻿using System.Reflection;
 
 namespace HandlebarsDotNet.Compiler
 {
@@ -7,21 +6,21 @@ namespace HandlebarsDotNet.Compiler
     {
         private readonly object _value;
         private readonly BindingContext _parent;
-		
+
         public string TemplatePath { get; private set; }
 
-		public EncodedTextWriter TextWriter { get; private set; }
+        public EncodedTextWriter TextWriter { get; private set; }
 
         public bool SuppressEncoding
         {
-            get { return TextWriter.SuppressEncoding;}
+            get { return TextWriter.SuppressEncoding; }
             set { TextWriter.SuppressEncoding = value; }
         }
 
-        public BindingContext(object value, EncodedTextWriter writer, BindingContext parent, string templatePath )
+        public BindingContext(object value, EncodedTextWriter writer, BindingContext parent, string templatePath)
         {
-	        TemplatePath = parent != null ? (parent.TemplatePath ?? templatePath) : templatePath;
-	        TextWriter = writer;
+            TemplatePath = parent != null ? (parent.TemplatePath ?? templatePath) : templatePath;
+            TextWriter = writer;
             _value = value;
             _parent = parent;
         }
@@ -61,22 +60,16 @@ namespace HandlebarsDotNet.Compiler
         {
             object returnValue;
             variableName = variableName.TrimStart('@');
-#if netstandard
-            var member = target.GetType().GetTypeInfo()
-                .GetMember(variableName, BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
-#else
-            var member = target.GetType()
-                .GetMember(variableName, BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
-#endif
+            var member = target.GetType().GetMember(variableName, BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
             if (member.Length > 0)
             {
                 if (member[0] is PropertyInfo)
                 {
-                    returnValue = ((PropertyInfo) member[0]).GetValue(target, null);
+                    returnValue = ((PropertyInfo)member[0]).GetValue(target, null);
                 }
                 else if (member[0] is FieldInfo)
                 {
-                    returnValue = ((FieldInfo) member[0]).GetValue(target);
+                    returnValue = ((FieldInfo)member[0]).GetValue(target);
                 }
                 else
                 {
@@ -96,7 +89,7 @@ namespace HandlebarsDotNet.Compiler
 
         public virtual BindingContext CreateChildContext(object value)
         {
-	        return new BindingContext(value, TextWriter, this, TemplatePath);
+            return new BindingContext(value, TextWriter, this, TemplatePath);
         }
     }
 }

--- a/source/Handlebars/Compiler/Translation/Expression/BlockHelperFunctionBinder.cs
+++ b/source/Handlebars/Compiler/Translation/Expression/BlockHelperFunctionBinder.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.IO;
-using System.Linq;
-using System.Linq.Expressions;
+﻿using System.Linq.Expressions;
 using System.Reflection;
 
 namespace HandlebarsDotNet.Compiler
@@ -38,19 +35,6 @@ namespace HandlebarsDotNet.Compiler
             var helper = CompilationContext.Configuration.BlockHelpers[bhex.HelperName.Replace("#", "")];
             var arguments = new Expression[]
             {
-#if netstandard
-                Expression.Property(
-                    CompilationContext.BindingContext,
-                    typeof(BindingContext).GetRuntimeProperty("TextWriter")),
-                Expression.New(
-                        typeof(HelperOptions).GetTypeInfo().GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic)[0],
-                        body,
-                        inversion),
-                Expression.Property(
-                    CompilationContext.BindingContext,
-                    typeof(BindingContext).GetRuntimeProperty("Value")),
-                Expression.NewArrayInit(typeof(object), bhex.Arguments)
-#else
                 Expression.Property(
                     CompilationContext.BindingContext,
                     typeof(BindingContext).GetProperty("TextWriter")),
@@ -62,7 +46,6 @@ namespace HandlebarsDotNet.Compiler
                     CompilationContext.BindingContext,
                     typeof(BindingContext).GetProperty("Value")),
                 Expression.NewArrayInit(typeof(object), bhex.Arguments)
-#endif
             };
             if (helper.Target != null)
             {

--- a/source/Handlebars/Compiler/Translation/Expression/IteratorBinder.cs
+++ b/source/Handlebars/Compiler/Translation/Expression/IteratorBinder.cs
@@ -80,11 +80,7 @@ namespace HandlebarsDotNet.Compiler
             return Expression.Block(
                 Expression.Assign(contextParameter,
                     Expression.New(
-#if netstandard
-                        typeof(IteratorBindingContext).GetTypeInfo().GetConstructor(new[] { typeof(BindingContext) }),
-#else
                         typeof(IteratorBindingContext).GetConstructor(new[] { typeof(BindingContext) }),
-#endif
                         new Expression[] { CompilationContext.BindingContext })),
                 Expression.Call(
 #if netstandard
@@ -97,7 +93,7 @@ namespace HandlebarsDotNet.Compiler
                         Expression.Convert(contextParameter, typeof(IteratorBindingContext)),
                         Expression.Convert(iex.Sequence, typeof(IEnumerable)),
                         fb.Compile(new [] { iex.Template }, contextParameter),
-                        fb.Compile(new [] { iex.IfEmpty }, CompilationContext.BindingContext) 
+                        fb.Compile(new [] { iex.IfEmpty }, CompilationContext.BindingContext)
                     }));
         }
 
@@ -107,11 +103,7 @@ namespace HandlebarsDotNet.Compiler
             return Expression.Block(
                 Expression.Assign(contextParameter,
                     Expression.New(
-#if netstandard
-                        typeof(ObjectEnumeratorBindingContext).GetTypeInfo().GetConstructor(new[] { typeof(BindingContext) }),
-#else
                         typeof(ObjectEnumeratorBindingContext).GetConstructor(new[] { typeof(BindingContext) }),
-#endif
                         new Expression[] { CompilationContext.BindingContext })),
                 Expression.Call(
 #if netstandard
@@ -124,7 +116,7 @@ namespace HandlebarsDotNet.Compiler
                         Expression.Convert(contextParameter, typeof(ObjectEnumeratorBindingContext)),
                         iex.Sequence,
                         fb.Compile(new [] { iex.Template }, contextParameter),
-                        fb.Compile(new [] { iex.IfEmpty }, CompilationContext.BindingContext) 
+                        fb.Compile(new [] { iex.IfEmpty }, CompilationContext.BindingContext)
                     }));
         }
 
@@ -134,11 +126,7 @@ namespace HandlebarsDotNet.Compiler
             return Expression.Block(
                 Expression.Assign(contextParameter,
                     Expression.New(
-#if netstandard
-                        typeof(ObjectEnumeratorBindingContext).GetTypeInfo().GetConstructor(new[] { typeof(BindingContext) }),
-#else
                         typeof(ObjectEnumeratorBindingContext).GetConstructor(new[] { typeof(BindingContext) }),
-#endif
                         new Expression[] { CompilationContext.BindingContext })),
                 Expression.Call(
 #if netstandard
@@ -151,7 +139,7 @@ namespace HandlebarsDotNet.Compiler
                         Expression.Convert(contextParameter, typeof(ObjectEnumeratorBindingContext)),
                         Expression.Convert(iex.Sequence, typeof(IEnumerable)),
                         fb.Compile(new [] { iex.Template }, contextParameter),
-                        fb.Compile(new [] { iex.IfEmpty }, CompilationContext.BindingContext) 
+                        fb.Compile(new [] { iex.IfEmpty }, CompilationContext.BindingContext)
                     }));
         }
 
@@ -161,11 +149,7 @@ namespace HandlebarsDotNet.Compiler
             return Expression.Block(
                 Expression.Assign(contextParameter,
                     Expression.New(
-#if netstandard
-                        typeof(ObjectEnumeratorBindingContext).GetTypeInfo().GetConstructor(new[] { typeof(BindingContext) }),
-#else
                         typeof(ObjectEnumeratorBindingContext).GetConstructor(new[] { typeof(BindingContext) }),
-#endif
                         new Expression[] { CompilationContext.BindingContext })),
                 Expression.Call(
 #if netstandard
@@ -178,17 +162,13 @@ namespace HandlebarsDotNet.Compiler
                         Expression.Convert(contextParameter, typeof(ObjectEnumeratorBindingContext)),
                         Expression.Convert(iex.Sequence, typeof(IDynamicMetaObjectProvider)),
                         fb.Compile(new [] { iex.Template }, contextParameter),
-                        fb.Compile(new [] { iex.IfEmpty }, CompilationContext.BindingContext) 
+                        fb.Compile(new [] { iex.IfEmpty }, CompilationContext.BindingContext)
                     }));
         }
 
         private static bool IsNonListDynamic(object target)
         {
-#if netstandard
-            var interfaces = target.GetType().GetTypeInfo().GetInterfaces();
-#else
             var interfaces = target.GetType().GetInterfaces();
-#endif
             return interfaces.Contains(typeof(IDynamicMetaObjectProvider))
                 && ((IDynamicMetaObjectProvider)target).GetMetaObject(Expression.Constant(target)).GetDynamicMemberNames().Any();
         }
@@ -198,7 +178,7 @@ namespace HandlebarsDotNet.Compiler
             return
                 target.GetType()
 #if netstandard
-                    .GetTypeInfo().GetInterfaces()
+                    .GetInterfaces()
                     .Where(i => i.GetTypeInfo().IsGenericType)
 
 #else
@@ -217,18 +197,10 @@ namespace HandlebarsDotNet.Compiler
             if (HandlebarsUtils.IsTruthy(target))
             {
                 context.Index = 0;
-#if netstandard
-                foreach (MemberInfo member in target.GetType().GetTypeInfo()
-#else
                 foreach (MemberInfo member in target.GetType()
-#endif
                     .GetProperties(BindingFlags.Instance | BindingFlags.Public).OfType<MemberInfo>()
                     .Concat(
-#if netstandard
-                        target.GetType().GetTypeInfo().GetFields(BindingFlags.Public | BindingFlags.Instance)
-#else
                         target.GetType().GetFields(BindingFlags.Public | BindingFlags.Instance)
-#endif
                     ))
                 {
                     context.Key = member.Name;
@@ -270,11 +242,7 @@ namespace HandlebarsDotNet.Compiler
                         foreach (var key in keys)
                         {
                             context.Key = key.ToString();
-#if netstandard
-                            var value = target.GetType().GetTypeInfo().GetMethod("get_Item").Invoke(target, new[] { key });
-#else
                             var value = target.GetType().GetMethod("get_Item").Invoke(target, new[] { key });
-#endif
                             context.First = (context.Index == 0);
                             template(context.TextWriter, value);
                             context.Index++;
@@ -353,7 +321,7 @@ namespace HandlebarsDotNet.Compiler
         private class IteratorBindingContext : BindingContext
         {
             public IteratorBindingContext(BindingContext context)
-                : base(context.Value, context.TextWriter, context.ParentContext, context.TemplatePath )
+                : base(context.Value, context.TextWriter, context.ParentContext, context.TemplatePath)
             {
             }
 
@@ -367,7 +335,7 @@ namespace HandlebarsDotNet.Compiler
         private class ObjectEnumeratorBindingContext : BindingContext
         {
             public ObjectEnumeratorBindingContext(BindingContext context)
-                : base(context.Value, context.TextWriter, context.ParentContext, context.TemplatePath )
+                : base(context.Value, context.TextWriter, context.ParentContext, context.TemplatePath)
             {
             }
 

--- a/source/Handlebars/Compiler/Translation/Expression/PartialBinder.cs
+++ b/source/Handlebars/Compiler/Translation/Expression/PartialBinder.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Linq.Expressions;
+#if netstandard
 using System.Reflection;
+#endif
 
 namespace HandlebarsDotNet.Compiler
 {
@@ -35,11 +37,7 @@ namespace HandlebarsDotNet.Compiler
             {
                 bindingContext = Expression.Call(
                     bindingContext,
-#if netstandard
-                    typeof(BindingContext).GetTypeInfo().GetMethod("CreateChildContext"),
-#else
-                    typeof (BindingContext).GetMethod("CreateChildContext"),
-#endif
+                    typeof(BindingContext).GetMethod("CreateChildContext"),
                     pex.Argument);
             }
 
@@ -111,14 +109,14 @@ namespace HandlebarsDotNet.Compiler
 
             try
             {
-                configuration.RegisteredTemplates[partialName]( context.TextWriter, context );
+                configuration.RegisteredTemplates[partialName](context.TextWriter, context);
                 return true;
             }
-            catch ( Exception exception )
+            catch (Exception exception)
             {
                 throw new HandlebarsRuntimeException(
                     $"Runtime error while rendering partial '{partialName}', see inner exception for more information",
-                    exception );
+                    exception);
             }
 
         }

--- a/source/Handlebars/DynamicViewModel.cs
+++ b/source/Handlebars/DynamicViewModel.cs
@@ -17,15 +17,10 @@ namespace HandlebarsDotNet
             Objects = objects;
         }
 
-
         public override IEnumerable<string> GetDynamicMemberNames()
         {
             return Objects.Select(o => o.GetType())
-#if netstandard
-                .SelectMany(t => t.GetTypeInfo().GetMembers(BindingFlags))
-#else
                 .SelectMany(t => t.GetMembers(BindingFlags))
-#endif
                 .Select(m => m.Name);
         }
 
@@ -35,11 +30,7 @@ namespace HandlebarsDotNet
             foreach (var target in Objects)
             {
                 var member = target.GetType()
-#if netstandard
-                    .GetTypeInfo().GetMember(binder.Name, BindingFlags);
-#else
                     .GetMember(binder.Name, BindingFlags);
-#endif
 
                 if (member.Length > 0)
                 {

--- a/source/_build nuget.cmd
+++ b/source/_build nuget.cmd
@@ -1,0 +1,3 @@
+dotnet restore
+dotnet pack -c Release Handlebars.NetStandard\project.json
+pause

--- a/source/global.json
+++ b/source/global.json
@@ -1,4 +1,3 @@
 {
-  "sdk" : { "version": "1.0.0-preview2-003121"},
   "projects": [ "Handlebars.NetStandard", "Handlebars.NetStandard.Test" ]
 }


### PR DESCRIPTION
1. Add support for .NetStandard 1.3
2. Add .NETPortable,Version=v4.0,Profile=Profile24

The NetStandard project contains now 3 frameworks:
- net45
- netstandard1.3
- portable40-net45+sl5

You can use the `_build nuget.cmd` file to create a NuGet whihc you can directly commit to NuGet.org