### PR TITLE
Iteration improvement

### DIFF
--- a/source/Handlebars/Compiler/Translation/Expression/IteratorBinder.cs
+++ b/source/Handlebars/Compiler/Translation/Expression/IteratorBinder.cs
@@ -97,7 +97,7 @@ namespace HandlebarsDotNet.Compiler
                         Expression.Convert(contextParameter, typeof(IteratorBindingContext)),
                         Expression.Convert(iex.Sequence, typeof(IEnumerable)),
                         fb.Compile(new [] { iex.Template }, contextParameter),
-                        fb.Compile(new [] { iex.IfEmpty }, CompilationContext.BindingContext)
+                        fb.Compile(new [] { iex.IfEmpty }, CompilationContext.BindingContext) 
                     }));
         }
 
@@ -124,7 +124,7 @@ namespace HandlebarsDotNet.Compiler
                         Expression.Convert(contextParameter, typeof(ObjectEnumeratorBindingContext)),
                         iex.Sequence,
                         fb.Compile(new [] { iex.Template }, contextParameter),
-                        fb.Compile(new [] { iex.IfEmpty }, CompilationContext.BindingContext)
+                        fb.Compile(new [] { iex.IfEmpty }, CompilationContext.BindingContext) 
                     }));
         }
 
@@ -151,7 +151,7 @@ namespace HandlebarsDotNet.Compiler
                         Expression.Convert(contextParameter, typeof(ObjectEnumeratorBindingContext)),
                         Expression.Convert(iex.Sequence, typeof(IEnumerable)),
                         fb.Compile(new [] { iex.Template }, contextParameter),
-                        fb.Compile(new [] { iex.IfEmpty }, CompilationContext.BindingContext)
+                        fb.Compile(new [] { iex.IfEmpty }, CompilationContext.BindingContext) 
                     }));
         }
 
@@ -178,7 +178,7 @@ namespace HandlebarsDotNet.Compiler
                         Expression.Convert(contextParameter, typeof(ObjectEnumeratorBindingContext)),
                         Expression.Convert(iex.Sequence, typeof(IDynamicMetaObjectProvider)),
                         fb.Compile(new [] { iex.Template }, contextParameter),
-                        fb.Compile(new [] { iex.IfEmpty }, CompilationContext.BindingContext)
+                        fb.Compile(new [] { iex.IfEmpty }, CompilationContext.BindingContext) 
                     }));
         }
 
@@ -190,7 +190,7 @@ namespace HandlebarsDotNet.Compiler
             var interfaces = target.GetType().GetInterfaces();
 #endif
             return interfaces.Contains(typeof(IDynamicMetaObjectProvider))
-                && ((IDynamicMetaObjectProvider) target).GetMetaObject(Expression.Constant(target)).GetDynamicMemberNames().Any();
+                && ((IDynamicMetaObjectProvider)target).GetMetaObject(Expression.Constant(target)).GetDynamicMemberNames().Any();
         }
 
         private static bool IsGenericDictionary(object target)
@@ -364,7 +364,7 @@ namespace HandlebarsDotNet.Compiler
         private class IteratorBindingContext : BindingContext
         {
             public IteratorBindingContext(BindingContext context)
-                : base(context.Value, context.TextWriter, context.ParentContext, context.TemplatePath)
+                : base(context.Value, context.TextWriter, context.ParentContext, context.TemplatePath )
             {
             }
 
@@ -378,7 +378,7 @@ namespace HandlebarsDotNet.Compiler
         private class ObjectEnumeratorBindingContext : BindingContext
         {
             public ObjectEnumeratorBindingContext(BindingContext context)
-                : base(context.Value, context.TextWriter, context.ParentContext, context.TemplatePath)
+                : base(context.Value, context.TextWriter, context.ParentContext, context.TemplatePath )
             {
             }
 
@@ -393,11 +393,11 @@ namespace HandlebarsDotNet.Compiler
         {
             if (member is PropertyInfo)
             {
-                return ((PropertyInfo) member).GetValue(instance, null);
+                return ((PropertyInfo)member).GetValue(instance, null);
             }
             if (member is FieldInfo)
             {
-                return ((FieldInfo) member).GetValue(instance);
+                return ((FieldInfo)member).GetValue(instance);
             }
             throw new InvalidOperationException("Requested member was not a field or property");
         }

--- a/source/Handlebars/Compiler/Translation/Expression/IteratorBinder.cs
+++ b/source/Handlebars/Compiler/Translation/Expression/IteratorBinder.cs
@@ -343,7 +343,9 @@ namespace HandlebarsDotNet.Compiler
                         context.Index++;
 
                         if (!context.Last)
+                        {
                             item = iter.Current;
+                        }
                     }
                 }
             }

--- a/source/Handlebars/Compiler/Translation/Expression/IteratorBinder.cs
+++ b/source/Handlebars/Compiler/Translation/Expression/IteratorBinder.cs
@@ -97,7 +97,7 @@ namespace HandlebarsDotNet.Compiler
                         Expression.Convert(contextParameter, typeof(IteratorBindingContext)),
                         Expression.Convert(iex.Sequence, typeof(IEnumerable)),
                         fb.Compile(new [] { iex.Template }, contextParameter),
-                        fb.Compile(new [] { iex.IfEmpty }, CompilationContext.BindingContext) 
+                        fb.Compile(new [] { iex.IfEmpty }, CompilationContext.BindingContext)
                     }));
         }
 
@@ -124,7 +124,7 @@ namespace HandlebarsDotNet.Compiler
                         Expression.Convert(contextParameter, typeof(ObjectEnumeratorBindingContext)),
                         iex.Sequence,
                         fb.Compile(new [] { iex.Template }, contextParameter),
-                        fb.Compile(new [] { iex.IfEmpty }, CompilationContext.BindingContext) 
+                        fb.Compile(new [] { iex.IfEmpty }, CompilationContext.BindingContext)
                     }));
         }
 
@@ -151,7 +151,7 @@ namespace HandlebarsDotNet.Compiler
                         Expression.Convert(contextParameter, typeof(ObjectEnumeratorBindingContext)),
                         Expression.Convert(iex.Sequence, typeof(IEnumerable)),
                         fb.Compile(new [] { iex.Template }, contextParameter),
-                        fb.Compile(new [] { iex.IfEmpty }, CompilationContext.BindingContext) 
+                        fb.Compile(new [] { iex.IfEmpty }, CompilationContext.BindingContext)
                     }));
         }
 
@@ -178,7 +178,7 @@ namespace HandlebarsDotNet.Compiler
                         Expression.Convert(contextParameter, typeof(ObjectEnumeratorBindingContext)),
                         Expression.Convert(iex.Sequence, typeof(IDynamicMetaObjectProvider)),
                         fb.Compile(new [] { iex.Template }, contextParameter),
-                        fb.Compile(new [] { iex.IfEmpty }, CompilationContext.BindingContext) 
+                        fb.Compile(new [] { iex.IfEmpty }, CompilationContext.BindingContext)
                     }));
         }
 
@@ -190,7 +190,7 @@ namespace HandlebarsDotNet.Compiler
             var interfaces = target.GetType().GetInterfaces();
 #endif
             return interfaces.Contains(typeof(IDynamicMetaObjectProvider))
-                && ((IDynamicMetaObjectProvider)target).GetMetaObject(Expression.Constant(target)).GetDynamicMemberNames().Any();
+                && ((IDynamicMetaObjectProvider) target).GetMetaObject(Expression.Constant(target)).GetDynamicMemberNames().Any();
         }
 
         private static bool IsGenericDictionary(object target)
@@ -321,7 +321,6 @@ namespace HandlebarsDotNet.Compiler
             }
         }
 
-        //TODO: make this a little less dumb
         private static void Iterate(
             IteratorBindingContext context,
             IEnumerable sequence,
@@ -329,14 +328,26 @@ namespace HandlebarsDotNet.Compiler
             Action<TextWriter, object> ifEmpty)
         {
             context.Index = 0;
-            int length = (sequence is IList ? ((IList)sequence).Count : sequence.Cast<object>().Count());
-            foreach (object item in sequence)
+
+            var iter = sequence.GetEnumerator();
+            using (iter as IDisposable)
             {
-                context.First = (context.Index == 0);
-                context.Last = (context.Index == length - 1);
-                template(context.TextWriter, item);
-                context.Index++;
+                if (iter.MoveNext())
+                {
+                    var item = iter.Current;
+                    while (!context.Last)
+                    {
+                        context.Last = !iter.MoveNext();
+                        context.First = (context.Index == 0);
+                        template(context.TextWriter, item);
+                        context.Index++;
+
+                        if (!context.Last)
+                            item = iter.Current;
+                    }
+                }
             }
+
             if (context.Index == 0)
             {
                 ifEmpty(context.TextWriter, context.Value);
@@ -353,7 +364,7 @@ namespace HandlebarsDotNet.Compiler
         private class IteratorBindingContext : BindingContext
         {
             public IteratorBindingContext(BindingContext context)
-                : base(context.Value, context.TextWriter, context.ParentContext, context.TemplatePath )
+                : base(context.Value, context.TextWriter, context.ParentContext, context.TemplatePath)
             {
             }
 
@@ -367,7 +378,7 @@ namespace HandlebarsDotNet.Compiler
         private class ObjectEnumeratorBindingContext : BindingContext
         {
             public ObjectEnumeratorBindingContext(BindingContext context)
-                : base(context.Value, context.TextWriter, context.ParentContext, context.TemplatePath )
+                : base(context.Value, context.TextWriter, context.ParentContext, context.TemplatePath)
             {
             }
 
@@ -382,11 +393,11 @@ namespace HandlebarsDotNet.Compiler
         {
             if (member is PropertyInfo)
             {
-                return ((PropertyInfo)member).GetValue(instance, null);
+                return ((PropertyInfo) member).GetValue(instance, null);
             }
             if (member is FieldInfo)
             {
-                return ((FieldInfo)member).GetValue(instance);
+                return ((FieldInfo) member).GetValue(instance);
             }
             throw new InvalidOperationException("Requested member was not a field or property");
         }


### PR DESCRIPTION
Changed the iterate method to not cause double-enumeration of true IEnumerables in order to get the Count/Length for knowing the last item - or in the words of the Todo note above the method "make this a little less dumb".

The foreach is unrolled to a while loop that 'caches' one item ahead to know when it has reached the last item without knowing the overall length.

All tests pass.