### PR TITLE
Simplify common partial registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,7 @@ string source =
 string partialSource =
 @"<strong>{{name}}</strong>";
 
-using (var reader = new StringReader(partialSource))
-{
-  var partialTemplate = Handlebars.Compile(reader);
-  Handlebars.RegisterTemplate("user", partialTemplate);
-}
+Handlebars.RegisterTemplate("user", partialSource);
 
 var template = Handlebars.Compile(source);
 

--- a/source/Handlebars.Test/PartialTests.cs
+++ b/source/Handlebars.Test/PartialTests.cs
@@ -31,6 +31,24 @@ namespace HandlebarsDotNet.Test
         }
 
         [Test]
+        public void BasicStringOnlyPartial()
+        {
+            string source = "Hello, {{>person}}!";
+
+            var template = Handlebars.Compile(source);
+
+            var data = new {
+                name = "Marc"
+            };
+
+            var partialSource = "{{name}}";           
+            Handlebars.RegisterTemplate("person", partialSource);            
+
+            var result = template(data);
+            Assert.AreEqual("Hello, Marc!", result);
+        }
+
+        [Test]
         public void BasicPartialWithContext()
         {
             string source = "Hello, {{>person leadDev}}!";

--- a/source/Handlebars/Handlebars.cs
+++ b/source/Handlebars/Handlebars.cs
@@ -34,6 +34,11 @@ namespace HandlebarsDotNet
             Instance.RegisterTemplate(templateName, template);
         }
 
+        public static void RegisterTemplate(string templateName, string template)
+        {
+            Instance.RegisterTemplate(templateName, template);
+        }
+
         public static void RegisterHelper(string helperName, HandlebarsHelper helperFunction)
         {
             Instance.RegisterHelper(helperName, helperFunction);

--- a/source/Handlebars/HandlebarsEnvironment.cs
+++ b/source/Handlebars/HandlebarsEnvironment.cs
@@ -80,7 +80,7 @@ namespace HandlebarsDotNet
             {
                 using (var reader = new StringReader(template))
                 {
-                    RegisterTemplate(templateName, Handlebars.Compile(reader));
+                    RegisterTemplate(templateName, Compile(reader));
                 }
             }
 

--- a/source/Handlebars/HandlebarsEnvironment.cs
+++ b/source/Handlebars/HandlebarsEnvironment.cs
@@ -76,6 +76,14 @@ namespace HandlebarsDotNet
                 }
             }
 
+            public void RegisterTemplate(string templateName, string template)
+            {
+                using (var reader = new StringReader(template))
+                {
+                    RegisterTemplate(templateName, Handlebars.Compile(reader));
+                }
+            }
+
             public void RegisterHelper(string helperName, HandlebarsHelper helperFunction)
             {
                 lock (_configuration)

--- a/source/Handlebars/IHandlebars.cs
+++ b/source/Handlebars/IHandlebars.cs
@@ -17,6 +17,8 @@ namespace HandlebarsDotNet
 
         void RegisterTemplate(string templateName, Action<TextWriter, object> template);
 
+        void RegisterTemplate(string templateName, string template);
+
         void RegisterHelper(string helperName, HandlebarsHelper helperFunction);
 
         void RegisterHelper(string helperName, HandlebarsBlockHelper helperFunction);


### PR DESCRIPTION
Added an overload/wrapper to allow partials to be registered from a string rather than requiring a StringReader. Simplifies common usage and should be a lot clearer for new users of the library.

I also updated the readme to show this overload instead of the StringReader.