### PR TITLE
Make debugType portable

### DIFF
--- a/source/Handlebars/Handlebars.csproj
+++ b/source/Handlebars/Handlebars.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <TargetFrameworks>net40;netstandard1.3</TargetFrameworks>
     <VersionPrefix>1.8.1</VersionPrefix>


### PR DESCRIPTION
Defining it as full I believe doesn't make it work on OSX/Linux