### PR TITLE
Updated conditional CSharp reference to net452

### DIFF
--- a/source/Handlebars/Handlebars.csproj
+++ b/source/Handlebars/Handlebars.csproj
@@ -25,7 +25,7 @@
     <RepositoryUrl>https://github.com/rexm/Handlebars.Net</RepositoryUrl>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)'=='net40'">
+  <ItemGroup Condition="'$(TargetFramework)'=='net452'">
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 


### PR DESCRIPTION
With the TFM being set to net452 (as per #213), "Microsoft.CSharp" wasn't being referenced, causing a CS0656 build error.

I've updated the reference condition to test for "net452".