### PR TITLE
Don't throw undefined binding exception when value is null

### DIFF
--- a/source/Handlebars.Test/BasicIntegrationTests.cs
+++ b/source/Handlebars.Test/BasicIntegrationTests.cs
@@ -74,6 +74,52 @@ namespace HandlebarsDotNet.Test
         }
 
         [Fact]
+        public void BasicPathThrowOnNestedUnresolvedBindingExpression()
+        {
+            var source = "Hello, {{foo.bar}}!";
+
+            var config = new HandlebarsConfiguration
+            {
+                ThrowOnUnresolvedBindingExpression = true
+            };
+            var handlebars = Handlebars.Create(config);
+            var template = handlebars.Compile(source);
+
+            var data = new
+            {
+                foo = (object)null
+            };
+            var ex = Assert.Throws<HandlebarsUndefinedBindingException>(() => template(data));
+            Assert.Equal("bar is undefined", ex.Message);
+        }
+
+        [Fact]
+        public void BasicPathNoThrowOnNullExpression()
+        {
+            var source =
+@"{{#if foo}}
+{{foo.bar}}
+{{else}}
+false
+{{/if}}
+";
+
+            var config = new HandlebarsConfiguration
+            {
+                ThrowOnUnresolvedBindingExpression = true
+            };
+            var handlebars = Handlebars.Create(config);
+            var template = handlebars.Compile(source);
+
+            var data = new
+            {
+                foo = (string)null
+            };
+            var result = template(data);
+            Assert.Contains("false", result);
+        }
+
+        [Fact]
         public void AssertHandlebarsUndefinedBindingException()
         {
             var source = "Hello, {{person.firstname}} {{person.lastname}}!";

--- a/source/Handlebars/Compiler/Translation/Expression/PathBinder.cs
+++ b/source/Handlebars/Compiler/Translation/Expression/PathBinder.cs
@@ -322,12 +322,12 @@ namespace HandlebarsDotNet.Compiler
             if (propertyInfo != null)
             {
                 var propertyValue = propertyInfo.GetValue(instance, null);
-                return propertyValue ?? new UndefinedBindingResult(resolvedMemberName, CompilationContext.Configuration);
+                return propertyValue;
             }
             if (preferredMember is FieldInfo)
             {
                 var fieldValue = ((FieldInfo)preferredMember).GetValue(instance);
-                return fieldValue ?? new UndefinedBindingResult(resolvedMemberName, CompilationContext.Configuration);
+                return fieldValue;
             }
             return new UndefinedBindingResult(resolvedMemberName, CompilationContext.Configuration);
         }


### PR DESCRIPTION
Commit 53e8b5315cbe5b1ed43123775509988de1e8f642 adds `ThrowOnUnresolvedBindingExpression` which I want to use to validate my templates.  However, the current implementation will throw a `HandlebarsUndefinedBindingException` when the property exists but is null.  This PR fixes that.

I am trying to use `HandlebarsUndefinedBindingException=true` with the following template:
```
{{#if Data}}
Operation: {{Data.Operation}}
{{/if}}
```