### PR TITLE
Added support for inline partials. People that are more familiar with…

### DIFF
--- a/source/Handlebars.Test/InlinePartialTests.cs
+++ b/source/Handlebars.Test/InlinePartialTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using Xunit;
-using System.IO;
+﻿using Xunit;
 
 namespace HandlebarsDotNet.Test
 {

--- a/source/Handlebars.Test/InlinePartialTests.cs
+++ b/source/Handlebars.Test/InlinePartialTests.cs
@@ -1,0 +1,343 @@
+﻿using System;
+using System.Collections.Generic;
+using Xunit;
+using System.IO;
+
+namespace HandlebarsDotNet.Test
+{
+    public class InlinePartialTests
+    {
+        [Fact]
+        public void BasicInlinePartial()
+        {
+            string source = "{{#*inline \"person\"}}{{name}}{{/inline}}Hello, {{>person}}!";
+
+            var template = Handlebars.Compile(source);
+
+            var data = new
+            {
+                name = "Marc"
+            };
+
+            var result = template(data);
+            Assert.Equal("Hello, Marc!", result);
+        }
+
+        [Fact]
+        public void BasicInlinePartialWithNameConflicts()
+        {
+            string source = "{{#*inline \"personConflict\"}}{{firstName}}{{/inline}}Hello, {{>personConflict}}!";
+
+            var template = Handlebars.Compile(source);
+
+            var data = new
+            {
+                firstName = "Marc",
+                lastName = "Jones"
+            };
+
+            var result = template(data);
+            Assert.Equal("Hello, Marc!", result);
+
+            string source2 = "{{#*inline \"personConflict\"}}{{firstName}} {{lastName}}{{/inline}}Hello, {{>personConflict}}!";
+
+            var template2 = Handlebars.Compile(source2);
+
+            var result2 = template2(data);
+
+            Assert.Equal("Hello, Marc Jones!", result2);
+
+            var rerunFirstResult = template(data);
+            Assert.Equal("Hello, Marc!", result);
+        }
+
+        [Fact]
+        public void BasicStringOnlyInlinePartial()
+        {
+            string source = "{{#*inline \"person\"}}{{name}}{{/inline}}Hello, {{>person}}!";
+
+            var template = Handlebars.Compile(source);
+
+            var data = new
+            {
+                name = "Marc"
+            };
+
+            var result = template(data);
+            Assert.Equal("Hello, Marc!", result);
+        }
+
+        [Fact]
+        public void BasicInlinePartialWithContext()
+        {
+            string source = "{{#*inline \"person\"}}{{name}}{{/inline}}Hello, {{>person leadDev}}!";
+
+            var template = Handlebars.Compile(source);
+
+            var data = new
+            {
+                leadDev = new
+                {
+                    name = "Marc"
+                }
+            };
+
+            var result = template(data);
+            Assert.Equal("Hello, Marc!", result);
+        }
+
+        [Fact]
+        public void BasicInlinePartialWithStringParameter()
+        {
+            string source = "{{#*inline \"person\"}}{{first}}{{/inline}}Hello, {{>person first='Pete'}}!";
+
+            var template = Handlebars.Compile(source);
+
+            var result = template(null);
+            Assert.Equal("Hello, Pete!", result);
+        }
+
+        [Fact]
+        public void BasicInlinePartialWithMultipleStringParameters()
+        {
+            string source = "{{#*inline \"person\"}}{{first}} {{last}}{{/inline}}Hello, {{>person first='Pete' last=\"Sampras\"}}!";
+
+            var template = Handlebars.Compile(source);
+
+            var result = template(null);
+            Assert.Equal("Hello, Pete Sampras!", result);
+        }
+
+        [Fact]
+        public void BasicInlinePartialWithContextParameter()
+        {
+            string source = "{{#*inline \"person\"}}{{first.name}}{{/inline}}Hello, {{>person first=leadDev.marc}}!";
+
+            var template = Handlebars.Compile(source);
+
+            var data = new
+            {
+                leadDev = new
+                {
+                    marc = new
+                    {
+                        name = "Marc"
+                    }
+                }
+            };
+
+            var result = template(data);
+            Assert.Equal("Hello, Marc!", result);
+        }
+
+        [Fact]
+        public void BasicInlinePartialWithContextAndStringParameters()
+        {
+            string source = "{{#*inline \"person\"}}{{first.name}} {{last}}{{/inline}}Hello, {{>person first=leadDev.marc last='Smith'}}!";
+
+            var template = Handlebars.Compile(source);
+
+            var data = new
+            {
+                leadDev = new
+                {
+                    marc = new
+                    {
+                        name = "Marc"
+                    }
+                }
+            };
+
+            var result = template(data);
+            Assert.Equal("Hello, Marc Smith!", result);
+        }
+
+        [Fact]
+        public void BasicInlinePartialWithTypedParameters()
+        {
+            string source = "{{#*inline \"person\"}}{{first}} {{last}}{{/inline}}Hello, {{>person first=1 last=true}}!";
+
+            var template = Handlebars.Compile(source);
+
+            var result = template(null);
+            Assert.Equal("Hello, 1 True!", result);
+        }
+
+        [Fact]
+        public void BasicInlinePartialWithStringParameterIncludingExpressionChars()
+        {
+            string source = "{{#*inline \"person\"}}{{first}}{{/inline}}Hello, {{>person first='Pe ({~te~}) '}}!";
+
+            var template = Handlebars.Compile(source);
+
+            var result = template(null);
+            Assert.Equal("Hello, Pe ({~te~}) !", result);
+        }
+
+        [Fact]
+        public void SuperfluousWhitespace()
+        {
+            string source = "{{#*inline \"person\"}}{{name}}{{/inline}}Hello, {{  >  person  }}!";
+
+            var template = Handlebars.Compile(source);
+
+            var data = new
+            {
+                name = "Marc"
+            };
+
+            var result = template(data);
+            Assert.Equal("Hello, Marc!", result);
+        }
+
+        [Fact]
+        public void BasicInlinePartialWithStringParametersAndImplicitContext()
+        {
+            string source = "{{#*inline \"person\"}}{{firstName}} {{lastName}}{{/inline}}Hello, {{>person lastName='Smith'}}!";
+
+            var template = Handlebars.Compile(source);
+
+            var data = new
+            {
+                firstName = "Marc",
+                lastName = "Jones"
+            };
+
+            var result = template(data);
+            Assert.Equal("Hello, Marc Smith!", result);
+        }
+
+        [Fact]
+        public void BasicInlinePartialWithEmptyParameterDoesNotFallback()
+        {
+            string source = "{{#*inline \"person\"}}{{firstName}} {{lastName}}{{/inline}}Hello, {{>person lastName=test}}!";
+
+            var template = Handlebars.Compile(source);
+
+            var data = new
+            {
+                firstName = "Marc",
+                lastName = "Jones"
+            };
+
+            var result = template(data);
+            Assert.Equal("Hello, Marc !", result);
+        }
+
+        [Fact]
+        public void BasicInlinePartialWithIncompleteChildContextDoesNotFallback()
+        {
+            string source = "{{#*inline \"person\"}}{{firstName}} {{lastName}}{{/inline}}Hello, {{>person leadDev}}!";
+
+            var template = Handlebars.Compile(source);
+
+            var data = new
+            {
+                firstName = "Pete",
+                lastName = "Jones",
+                leadDev = new
+                {
+                    firstName = "Marc"
+                }
+            };
+
+            var result = template(data);
+            Assert.Equal("Hello, Marc !", result);
+        }
+
+        [Fact]
+        public void BasicBlockInlinePartial()
+        {
+            string source = "Hello, {{#>personInline}}friend{{/personInline}}!";
+
+            var template = Handlebars.Compile(source);
+
+            var data = new
+            {
+                firstName = "Pete",
+                lastName = "Jones"
+            };
+
+            var result1 = template(data);
+            Assert.Equal("Hello, friend!", result1);
+
+            source = "{{#*inline \"personInline\"}}{{firstName}} {{lastName}}{{/inline}}" + source;
+            template = Handlebars.Compile(source);
+
+            var result2 = template(data);
+            Assert.Equal("Hello, Pete Jones!", result2);
+        }
+
+        [Fact]
+        public void BasicBlockInlinePartialWithArgument()
+        {
+            string source = "Hello, {{#>personInline arg='Todd'}}friend{{/personInline}}!";
+
+            var template = Handlebars.Compile(source);
+
+            var data = new
+            {
+                firstName = "Pete",
+                lastName = "Jones"
+            };
+
+            var result1 = template(data);
+            Assert.Equal("Hello, friend!", result1);
+
+            source = "{{#*inline \"personInline\"}}{{arg}}{{/inline}}" + source;
+            template = Handlebars.Compile(source);
+
+            var result2 = template(data);
+            Assert.Equal("Hello, Todd!", result2);
+        }
+
+        [Fact]
+        public void BlockinlinePartialWithSpecialNamedPartial()
+        {
+            string source = "{{#*inline \"myPartial\"}}this is {{> @partial-block }} content{{/inline}}Well, {{#>myPartial}}some test{{/myPartial}} !";
+
+            var template = Handlebars.Compile(source);
+
+            var data = new { };
+            var result = template(data);
+
+            Assert.Equal("Well, this is some test content !", result);
+        }
+
+        [Fact]
+        public void BlockInlinePartialWithNestedSpecialNamedPartial()
+        {
+            string source = "{{#*inline \"partial2\"}}that {{> @partial-block}} great {{firstName}}{{/inline}}" 
+                          + "{{#*inline \"partial1\"}}this is {{> @partial-block }} content {{#>partial2}}works{{/partial2}} {{lastName}}{{/inline}}"
+                          + "Well, {{#>partial1}}some test{{/partial1}} !";
+
+
+            var template = Handlebars.Compile(source);
+
+            //var partialSource1 = "this is {{> @partial-block }} content {{#>partial2}}works{{/partial2}} {{lastName}}";
+            //using (var reader = new StringReader(partialSource1))
+            //{
+            //    var partialTemplate = Handlebars.Compile(reader);
+            //    Handlebars.RegisterTemplate("partial1", partialTemplate);
+            //}
+
+            //var partialSource2 = "that {{> @partial-block}} great {{firstName}}";
+            //using (var reader = new StringReader(partialSource2))
+            //{
+            //    var partialTemplate = Handlebars.Compile(reader);
+            //    Handlebars.RegisterTemplate("partial2", partialTemplate);
+            //}
+
+            var data = new
+            {
+                firstName = "Pete",
+                lastName = "Jones"
+            };
+            var result = template(data);
+
+            Assert.Equal("Well, this is some test content that works great Pete Jones !", result);
+        }
+
+    }
+}
+

--- a/source/Handlebars/BuiltinHelpers.cs
+++ b/source/Handlebars/BuiltinHelpers.cs
@@ -25,6 +25,12 @@ namespace HandlebarsDotNet
             }
         }
 
+        [Description("*inline")]
+        public static void Inline(TextWriter output, HelperOptions options, dynamic context, params object[] arguments)
+        {   //there may be a better way to do this, but leaving these blank seems to work.
+
+        }
+
         public static IEnumerable<KeyValuePair<string, HandlebarsHelper>> Helpers
         {
             get

--- a/source/Handlebars/BuiltinHelpers.cs
+++ b/source/Handlebars/BuiltinHelpers.cs
@@ -35,7 +35,8 @@ namespace HandlebarsDotNet
             }
 
             //This helper needs the "context" var to be the complete BindingContext as opposed to just the
-            //data { firstName: "todd" }. The full BindingContext is needed for registering the partial templates
+            //data { firstName: "todd" }. The full BindingContext is needed for registering the partial templates.
+            //This magic happens in BlockHelperFunctionbinder.VisitBlockHelperExpression
 
             if (context as BindingContext == null)
             {

--- a/source/Handlebars/Compiler/FunctionBuilder.cs
+++ b/source/Handlebars/Compiler/FunctionBuilder.cs
@@ -59,6 +59,7 @@ namespace HandlebarsDotNet.Compiler
         {
             try
             {
+
                 var expression = Compile(expressions, null, templatePath);
                 return ((Expression<Action<TextWriter, object>>)expression).Compile();
             }

--- a/source/Handlebars/Compiler/Lexer/Converter/BlockAccumulators/BlockHelperAccumulatorContext.cs
+++ b/source/Handlebars/Compiler/Lexer/Converter/BlockAccumulators/BlockHelperAccumulatorContext.cs
@@ -48,7 +48,7 @@ namespace HandlebarsDotNet.Compiler
 
         private bool IsClosingNode(Expression item)
         {
-            var helperName = _startingNode.HelperName.Replace("#", "");
+            var helperName = _startingNode.HelperName.Replace("#", "").Replace("*", "");
             return item is PathExpression && ((PathExpression)item).Path == "/" + helperName;
         }
 

--- a/source/Handlebars/Compiler/Translation/Expression/BlockHelperFunctionBinder.cs
+++ b/source/Handlebars/Compiler/Translation/Expression/BlockHelperFunctionBinder.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq.Expressions;
+﻿using System.Linq.Expressions;
 using System.Reflection;
 
 namespace HandlebarsDotNet.Compiler

--- a/source/Handlebars/Compiler/Translation/Expression/BlockHelperFunctionBinder.cs
+++ b/source/Handlebars/Compiler/Translation/Expression/BlockHelperFunctionBinder.cs
@@ -47,6 +47,25 @@ namespace HandlebarsDotNet.Compiler
                     typeof(BindingContext).GetProperty("Value")),
                 Expression.NewArrayInit(typeof(object), bhex.Arguments)
             };
+
+
+            //this is the hackiest part of the inline partial PR. This codebase looks like
+            //it would take me a long time to figure out. Stuffing this here makes it work though.
+            //Hopefully you have a better idea of where this should go
+            if (bhex.HelperName == "#*inline")
+            {   
+                //This block is an inline block so we will compile it and register it as a partial template
+                var args = bhex.Arguments.GetEnumerator();
+                args.MoveNext();
+
+                var partialName = ((ConstantExpression)args.Current).Value.ToString();
+
+                var compiledPartial = fb.Compile(((BlockExpression)bhex.Body).Expressions, null);
+                    
+                CompilationContext.Configuration.RegisteredTemplates.AddOrUpdate(partialName, compiledPartial);
+            }
+
+
             if (helper.Target != null)
             {
                 return Expression.Call(

--- a/source/Handlebars/Compiler/Translation/Expression/PartialBinder.cs
+++ b/source/Handlebars/Compiler/Translation/Expression/PartialBinder.cs
@@ -107,6 +107,14 @@ namespace HandlebarsDotNet.Compiler
                 PartialBlockTemplate = partialBlockTemplate
             };
 
+            //if we have an inline partial, skip the file system and RegisteredTemplates collection
+            if (context.InlinePartialTemplates.ContainsKey(partialName))
+            {
+                context.InlinePartialTemplates[partialName](context.TextWriter, context);
+                return true;
+            }
+
+            
             if (configuration.RegisteredTemplates.ContainsKey(partialName) == false)
             {
                 if (configuration.FileSystem != null && context.TemplatePath != null)
@@ -151,7 +159,7 @@ namespace HandlebarsDotNet.Compiler
         private class PartialBindingContext : BindingContext
         {
             public PartialBindingContext(BindingContext context)
-                : base(context.Value, context.TextWriter, context.ParentContext, context.TemplatePath)
+                : base(context.Value, context.TextWriter, context.ParentContext, context.TemplatePath, context)
             {
             }
 


### PR DESCRIPTION
… the codbase should look at some of the hackier bits. I left comments to explain the thinking in the code.

The template below can be used as a simple test. I have done some pretty complicated nesting of inline partials with parameters and different contexts and everything seems to work pretty well. I'm sure some aspects of this can and should be improved so please feel free to put things where they should be.

{{#*inline "inlineTest"}}
    <strong>hello inline partial</strong>
{{/inline}}
{{> inlineTest}}