### PR TITLE
Migrate test to HtmlAgilityPack (more maintained)

### DIFF
--- a/source/Handlebars.Test/Handlebars.Test.csproj
+++ b/source/Handlebars.Test/Handlebars.Test.csproj
@@ -14,6 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="HtmlAgilityPack" Version="1.6.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="xunit" Version="2.2.0" />
@@ -21,7 +22,6 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net461'">
-    <PackageReference Include="CsQuery" Version="1.3.4" />
     <PackageReference Include="Microsoft.AspNet.WebPages" Version="3.2.3" />
     <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
   </ItemGroup>

--- a/source/Handlebars.Test/ViewEngine/CasparTests.cs
+++ b/source/Handlebars.Test/ViewEngine/CasparTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using HtmlAgilityPack;
 using Xunit;
 
 namespace HandlebarsDotNet.Test.ViewEngine
@@ -32,9 +33,13 @@ namespace HandlebarsDotNet.Test.ViewEngine
                     }
                 }
             });
-            var cq = CsQuery.CQ.CreateDocument(output);
-            Assert.Equal("My Post Title", cq["h2.post-title a"].Text());
+
+            var doc = new HtmlDocument();
+            doc.LoadHtml(output);
+            var postTitle = doc.DocumentNode.SelectSingleNode("//h2[@class='post-title']/a").InnerText;
+            Assert.Equal("My Post Title", postTitle);
         }
+
         [Fact]
         public void CanRenderCasparPostTemplate()
         {
@@ -59,8 +64,10 @@ namespace HandlebarsDotNet.Test.ViewEngine
                     post_class = "somepostclass"
                 }
             });
-            var cq = CsQuery.CQ.CreateDocument(output);
-            Assert.Equal("My Post Title", cq["h1.post-title"].Html());
+            var doc = new HtmlDocument();
+            doc.LoadHtml(output);
+            var postTitle = doc.DocumentNode.SelectSingleNode("//h1[@class='post-title']").InnerText;
+            Assert.Equal("My Post Title", postTitle);
         }
 
         private static void AddHelpers(IHandlebars handlebars)
@@ -95,8 +102,10 @@ namespace HandlebarsDotNet.Test.ViewEngine
                     post_class = "somepostclass"
                 }
             });
-            var cq = CsQuery.CQ.CreateDocument(output);
-            Assert.Equal("My Post Title", cq["h1.post-title"].Html());
+            var doc = new HtmlDocument();
+            doc.LoadHtml(output);
+            var postTitle = doc.DocumentNode.SelectSingleNode("//h1[@class='post-title']").InnerText;
+            Assert.Equal("My Post Title", postTitle);
         }
 
         [Fact]
@@ -130,10 +139,12 @@ namespace HandlebarsDotNet.Test.ViewEngine
                     }
                 }
             });
-            var cq = CsQuery.CQ.CreateDocument(output);
-            Assert.Equal("My Post Title", cq["h2.post-title a"].Text());
-        }
 
+            var doc = new HtmlDocument();
+            doc.LoadHtml(output);
+            var postTitle = doc.DocumentNode.SelectSingleNode("//h2[@class='post-title']/a").InnerText;
+            Assert.Equal("My Post Title", postTitle);
+        }
 
         class DiskFileSystem : ViewEngineFileSystem
         {


### PR DESCRIPTION
CsQuery hasn't been updated in the past 2 years. HtmlAgilityPack it's currently mantained. HtmlAgilityPack also supports dotnetcore, while for the test project I don't know if it's relevant. 