### PR TITLE
Add IsUndefinedBindingResult

### DIFF
--- a/source/Handlebars/HandlebarsUtils.cs
+++ b/source/Handlebars/HandlebarsUtils.cs
@@ -11,6 +11,11 @@ namespace HandlebarsDotNet
         {
             return !IsFalsy(value);
         }
+        
+        public static bool IsUndefinedBindingResult(object value)
+        {
+            return value is UndefinedBindingResult;
+        }
 
         public static bool IsFalsy(object value)
         {


### PR DESCRIPTION
Add a public util method that checks for the internal type `UndefinedBindingResult` so a registered helper can check for an undefined binding result.