### PR TITLE
Test and fix for empty iterator block bodies

### DIFF
--- a/source/Handlebars.Test/IteratorTests.cs
+++ b/source/Handlebars.Test/IteratorTests.cs
@@ -25,6 +25,26 @@ namespace HandlebarsDotNet.Test
         }
 
         [Fact]
+        public void EmptyElementTemplate()
+        {
+            var source = "Hello,{{#each people}}{{/each}}";
+            var template = Handlebars.Compile(source);
+            var data = new
+            {
+                people = new[]{
+                    new {
+                        name = "Erik"
+                    },
+                    new {
+                        name = "Helen"
+                    }
+                }
+            };
+            var result = template(data);
+            Assert.Equal("Hello,", result);
+        }
+
+        [Fact]
         public void WithIndex()
         {
             var source = "Hello,{{#each people}}\n{{@index}}. {{name}}{{/each}}";

--- a/source/Handlebars/Compiler/Lexer/Converter/BlockAccumulators/IteratorBlockAccumulatorContext.cs
+++ b/source/Handlebars/Compiler/Lexer/Converter/BlockAccumulators/IteratorBlockAccumulatorContext.cs
@@ -40,7 +40,7 @@ namespace HandlebarsDotNet.Compiler
             if (IsClosingNode(item))
             {
                 // If the template has no content within the block, e.g. `{{#each ...}}{{/each}`, then the block body is a no-op.
-                var bodyStatements = _body.Count != 0 ? _body : new List<Expression>{ Expression.Constant(null, typeof(object)) };
+                var bodyStatements = _body.Count != 0 ? _body : new List<Expression>{ Expression.Empty() };
                 if (_accumulatedExpression == null)
                 {
                     _accumulatedExpression = HandlebarsExpression.Iterator(

--- a/source/Handlebars/Compiler/Lexer/Converter/BlockAccumulators/IteratorBlockAccumulatorContext.cs
+++ b/source/Handlebars/Compiler/Lexer/Converter/BlockAccumulators/IteratorBlockAccumulatorContext.cs
@@ -39,18 +39,20 @@ namespace HandlebarsDotNet.Compiler
         {
             if (IsClosingNode(item))
             {
+                // If the template has no content within the block, e.g. `{{#each ...}}{{/each}`, then the block body is a no-op.
+                var bodyStatements = _body.Count != 0 ? _body : new List<Expression>{ Expression.Constant(null, typeof(object)) };
                 if (_accumulatedExpression == null)
                 {
                     _accumulatedExpression = HandlebarsExpression.Iterator(
                         _startingNode.Arguments.Single(),
-                        Expression.Block(_body));
+                        Expression.Block(bodyStatements));
                 }
                 else
                 {
                     _accumulatedExpression = HandlebarsExpression.Iterator(
                         ((IteratorExpression)_accumulatedExpression).Sequence,
                         ((IteratorExpression)_accumulatedExpression).Template,
-                        Expression.Block(_body));
+                        Expression.Block(bodyStatements));
                 }
                 return true;
             }


### PR DESCRIPTION
Hi! Thanks for the great library.

I've reproduced #114 and and #136, which I believe to be the same issue (both reports include the same exception message and similar conditions).

```csharp
[Fact]
public void EmptyElementTemplate()
{
    var source = "Hello,{{#each people}}{{/each}}";
    var template = Handlebars.Compile(source);
    var data = new
    {
        people = new[]{
            new {
                name = "Erik"
            },
            new {
                name = "Helen"
            }
        }
    };
    var result = template(data);
    Assert.Equal("Hello,", result);
}
```

The test case shows an `#each` block with no content. The exception generated is:

```
System.ArgumentException : Non-empty collection required
Parameter name: expressions
   at System.Dynamic.Utils.ContractUtils.RequiresNotEmpty[T](ICollection`1 collection, String paramName)
   at System.Linq.Expressions.Expression.Block(IEnumerable`1 variables, IEnumerable`1 expressions)
   at HandlebarsDotNet.Compiler.IteratorBlockAccumulatorContext.IsClosingElement(Expression item)
   at HandlebarsDotNet.Compiler.BlockAccumulator.AccumulateBlock(IEnumerator`1 enumerator, BlockAccumulatorContext context)
   at HandlebarsDotNet.Compiler.BlockAccumulator.<ConvertTokens>d__3.MoveNext()
   at System.Collections.Generic.List`1..ctor(IEnumerable`1 collection)
   at System.Linq.Enumerable.ToList[TSource](IEnumerable`1 source)
   at HandlebarsDotNet.Compiler.BlockAccumulator.Accumulate(IEnumerable`1 tokens, HandlebarsConfiguration configuration)
   at HandlebarsDotNet.Compiler.ExpressionBuilder.ConvertTokensToExpressions(IEnumerable`1 tokens)
   at HandlebarsDotNet.Compiler.HandlebarsCompiler.Compile(TextReader source)
   at HandlebarsDotNet.Handlebars.HandlebarsEnvironment.Compile(TextReader template)
   at HandlebarsDotNet.Handlebars.HandlebarsEnvironment.Compile(String template)
   at HandlebarsDotNet.Handlebars.Compile(String template)
   at HandlebarsDotNet.Test.IteratorTests.EmptyElementTemplate() in C:\Development\temp\Handlebars.Net\source\Handlebars.Test\IteratorTests.cs:line 31
```

The problem is that when the `Expression.Block()` is created that represents processing of the different tokens inside the iterator, there are no statements to include in the block. `Expression.Block()` fails with the exception above if the block is empty in this way.

I've worked around this by providing a no-op statement in place of the body - I'm not familiar enough with the codebase to tell whether this is reasonable, or if a fix at another layer would be more appropriate, but the tests are passing and the performance impact in the normal case should be only a comparison between the body statement count and zero.

Let me know if another fix would be more appropriate, happy to dig in :-) Cheers!
