### PR TITLE
Prevent failures when handling empty block bodies in helpers

### DIFF
--- a/source/Handlebars.Test/HelperTests.cs
+++ b/source/Handlebars.Test/HelperTests.cs
@@ -235,6 +235,24 @@ namespace HandlebarsDotNet.Test
             Assert.Equal(expected, output);
         }
 
+        [Fact]
+        public void EmptyBlockHelperWithInversion()
+        {
+            var source = "{{#ifCond}}{{else}}Inverse{{/ifCond}}";
+
+            Handlebars.RegisterHelper("ifCond", (writer, options, context, arguments) => {
+                options.Inverse(writer, (object)context);
+            });
+
+            var data = new
+            {
+            };
+
+            var template = Handlebars.Compile(source);
+
+            var output = template(data);
+            Assert.Equal("Inverse", output);
+        }
     }
 }
 

--- a/source/Handlebars/Compiler/Lexer/Converter/BlockAccumulators/BlockHelperAccumulatorContext.cs
+++ b/source/Handlebars/Compiler/Lexer/Converter/BlockAccumulators/BlockHelperAccumulatorContext.cs
@@ -25,7 +25,7 @@ namespace HandlebarsDotNet.Compiler
         {
             if (IsInversionBlock(item))
             {
-                _accumulatedBody = Expression.Block(_body);
+                _accumulatedBody = GetBlockBody();
                 _body = new List<Expression>();
             }
             else
@@ -56,17 +56,14 @@ namespace HandlebarsDotNet.Compiler
         {
             if (_accumulatedBody == null)
             {
-                _accumulatedBody = Expression.Block(_body);
+                _accumulatedBody = GetBlockBody();
                 _accumulatedInversion = Expression.Block(Expression.Empty());
             }
-            else if (_accumulatedInversion == null && _body.Any())
+            else if (_accumulatedInversion == null)
             {
-                _accumulatedInversion = Expression.Block(_body);
+                _accumulatedInversion = GetBlockBody();
             }
-            else
-            {
-                _accumulatedInversion = Expression.Block(Expression.Empty());
-            }
+
             return HandlebarsExpression.BlockHelper(
                 _startingNode.HelperName,
                 _startingNode.Arguments,
@@ -74,6 +71,12 @@ namespace HandlebarsDotNet.Compiler
                 _accumulatedInversion);
         }
 
+        private Expression GetBlockBody()
+        {
+            return _body.Any() ?
+                Expression.Block(_body) :
+                Expression.Block(Expression.Empty());
+        }
     }
 }
 


### PR DESCRIPTION
This fixes another instance of the "empty block body" problem addressed by #250 - in this case, when using helpers for conditionals - `{{#myIf}}{{else}}{{/myIf}}`.

The failure here is identical to the one covered in the other PR.