### PR TITLE
Fixed UpperCamelCaseInputModelNaming() Test Case

### DIFF
--- a/source/Handlebars.Test/CustomConfigurationTests.cs
+++ b/source/Handlebars.Test/CustomConfigurationTests.cs
@@ -40,7 +40,7 @@ namespace HandlebarsDotNet.Test
         [Fact]
         public void UpperCamelCaseInputModelNaming()
         {
-            var template = "Hello {{person.name}} {{person.surname}} from {{person.address.homeCountry}}. You're {{{description}}}.";
+            var template = "Hello {{person.name}} {{person.surname}} from {{person.address.HomeCountry}}. You're {{{description}}}.";
             var output = this.HandlebarsInstance.Compile(template).Invoke(Value);
 
             Assert.Equal(output, ExpectedOutput);


### PR DESCRIPTION
Updated the test case from person.address.homeCountry (lower Camel) to person.address.HomeCountry (upper Camel).