### PR TITLE
Master

### DIFF
--- a/source/Handlebars.Test/PartialResolverTests.cs
+++ b/source/Handlebars.Test/PartialResolverTests.cs
@@ -1,0 +1,43 @@
+using Xunit;
+
+namespace HandlebarsDotNet.Test
+{
+    public class PartialResolverTests
+    {
+        public class CustomPartialResolver : IPartialTemplateResolver
+        {
+            public bool TryRegisterPartial(IHandlebars env, string partialName, string templatePath)
+            {
+                if (partialName == "person")
+                {
+                    env.RegisterTemplate("person", "{{name}}");
+                    return true;
+                }
+
+                return false;
+            }
+        }
+
+        [Fact]
+        public void BasicPartial()
+        {
+            string source = "Hello, {{>person}}!";
+
+            var handlebars = Handlebars.Create(new HandlebarsConfiguration
+            {
+                PartialTemplateResolver = new CustomPartialResolver()
+            });
+
+
+            var template = handlebars.Compile(source);
+
+            var data = new {
+                name = "Marc"
+            };
+            
+            var result = template(data);
+            Assert.Equal("Hello, Marc!", result);
+        }
+    }
+}
+

--- a/source/Handlebars.Test/PartialTests.cs
+++ b/source/Handlebars.Test/PartialTests.cs
@@ -596,6 +596,31 @@ namespace HandlebarsDotNet.Test
             var ex = Assert.Throws<HandlebarsRuntimeException>(() => template(data));
             Assert.Equal("Referenced partial name @partial-block could not be resolved", ex.Message);
         }
+
+        public class TestMissingPartialTemplateHandler : IMissingPartialTemplateHandler
+        {
+            public void Handle(HandlebarsConfiguration configuration, string partialName, TextWriter textWriter)
+            {
+                textWriter.Write($"Partial Not Found: {partialName}");
+            }
+        }
+
+        [Fact]
+        public void MissingPartialTemplateHandler()
+        {
+            var source = "Missing template should not throw exception: {{> missing }}";
+
+            var handlebars = Handlebars.Create(new HandlebarsConfiguration
+            {
+                MissingPartialTemplateHandler = new TestMissingPartialTemplateHandler()
+            });
+
+            var template = handlebars.Compile(source);
+            var data = new { };
+            var result = template(data);
+
+            Assert.Equal("Missing template should not throw exception: Partial Not Found: missing", result);
+        }
     }
 }
 

--- a/source/Handlebars/Compiler/Translation/Expression/PartialBinder.cs
+++ b/source/Handlebars/Compiler/Translation/Expression/PartialBinder.cs
@@ -73,8 +73,17 @@ namespace HandlebarsDotNet.Compiler
             if (!InvokePartial(partialName, context, configuration))
             {
                 if (context.PartialBlockTemplate == null)
-                    throw new HandlebarsRuntimeException(
-                        string.Format("Referenced partial name {0} could not be resolved", partialName));
+                {
+                    if (configuration.MissingPartialTemplateHandler != null)
+                    {
+                        configuration.MissingPartialTemplateHandler.Handle(configuration, partialName, context.TextWriter);
+                        return;
+                    }
+                    else
+                    {
+                        throw new HandlebarsRuntimeException(string.Format("Referenced partial name {0} could not be resolved", partialName));
+                    }
+                }
 
                 context.PartialBlockTemplate(context.TextWriter, context);
             }

--- a/source/Handlebars/Compiler/Translation/Expression/PartialBinder.cs
+++ b/source/Handlebars/Compiler/Translation/Expression/PartialBinder.cs
@@ -102,30 +102,14 @@ namespace HandlebarsDotNet.Compiler
                 context.InlinePartialTemplates[partialName](context.TextWriter, context);
                 return true;
             }
-
+            
+            // Partial is not found, so call the resolver and attempt to load it.
             if (configuration.RegisteredTemplates.ContainsKey(partialName) == false)
             {
-                if (configuration.FileSystem != null && context.TemplatePath != null)
+                if (configuration.PartialTemplateResolver == null 
+                    || configuration.PartialTemplateResolver.TryRegisterPartial(Handlebars.Create(configuration), partialName, context.TemplatePath) == false)
                 {
-                    var partialPath = configuration.FileSystem.Closest(context.TemplatePath,
-                        "partials/" + partialName + ".hbs");
-                    if (partialPath != null)
-                    {
-                        var compiled = Handlebars.Create(configuration)
-                            .CompileView(partialPath);
-                        configuration.RegisteredTemplates.Add(partialName, (writer, o) =>
-                        {
-                            writer.Write(compiled(o));
-                        });
-                    }
-                    else
-                    {
-                        // Failed to find partial in filesystem
-                        return false;
-                    }
-                }
-                else
-                {
+                    // Template not found.
                     return false;
                 }
             }

--- a/source/Handlebars/FileSystemPartialTemplateResolver.cs
+++ b/source/Handlebars/FileSystemPartialTemplateResolver.cs
@@ -1,0 +1,41 @@
+﻿using System;
+
+namespace HandlebarsDotNet
+{
+    public class FileSystemPartialTemplateResolver : IPartialTemplateResolver
+    {
+        public bool TryRegisterPartial(IHandlebars env, string partialName, string templatePath)
+        {
+            if (env == null)
+            {
+                throw new ArgumentNullException(nameof(env));
+            }
+
+            if (env.Configuration?.FileSystem == null || templatePath == null || partialName == null)
+            {
+                return false;
+            }
+
+            var partialPath = env.Configuration.FileSystem.Closest(templatePath,
+                "partials/" + partialName + ".hbs");
+
+            if (partialPath != null)
+            {
+                var compiled = env
+                    .CompileView(partialPath);
+
+                env.Configuration.RegisteredTemplates.Add(partialName, (writer, o) =>
+                {
+                    writer.Write(compiled(o));
+                });
+
+                return true;
+            }
+            else
+            {
+                // Failed to find partial in filesystem
+                return false;
+            }
+        }
+    }
+}

--- a/source/Handlebars/HandlebarsConfiguration.cs
+++ b/source/Handlebars/HandlebarsConfiguration.cs
@@ -29,6 +29,11 @@ namespace HandlebarsDotNet
         /// </summary>
         public IPartialTemplateResolver PartialTemplateResolver { get; set; }
 
+        /// <summary>
+        /// The handler called when a partial template cannot be found.
+        /// </summary>
+        public IMissingPartialTemplateHandler MissingPartialTemplateHandler { get; set; }
+
         public HandlebarsConfiguration()
         {
             this.Helpers = new Dictionary<string, HandlebarsHelper>(StringComparer.OrdinalIgnoreCase);

--- a/source/Handlebars/HandlebarsConfiguration.cs
+++ b/source/Handlebars/HandlebarsConfiguration.cs
@@ -1,7 +1,7 @@
-﻿using System;
+﻿using HandlebarsDotNet.Compiler.Resolvers;
+using System;
 using System.Collections.Generic;
 using System.IO;
-using HandlebarsDotNet.Compiler.Resolvers;
 
 namespace HandlebarsDotNet
 {
@@ -20,12 +20,20 @@ namespace HandlebarsDotNet
         public ViewEngineFileSystem FileSystem { get; set; }
 
 	    public string UnresolvedBindingFormatter { get; set; }
+
 	    public bool ThrowOnUnresolvedBindingExpression { get; set; }
 
-	    public HandlebarsConfiguration()
+        /// <summary>
+        /// The resolver used for unregistered partials. Defaults
+        /// to the <see cref="FileSystemPartialTemplateResolver"/>.
+        /// </summary>
+        public IPartialTemplateResolver PartialTemplateResolver { get; set; }
+
+        public HandlebarsConfiguration()
         {
             this.Helpers = new Dictionary<string, HandlebarsHelper>(StringComparer.OrdinalIgnoreCase);
             this.BlockHelpers = new Dictionary<string, HandlebarsBlockHelper>(StringComparer.OrdinalIgnoreCase);
+            this.PartialTemplateResolver = new FileSystemPartialTemplateResolver();
             this.RegisteredTemplates = new Dictionary<string, Action<TextWriter, object>>(StringComparer.OrdinalIgnoreCase);
             this.TextEncoder = new HtmlEncoder();
 	        this.ThrowOnUnresolvedBindingExpression = false;

--- a/source/Handlebars/IMissingPartialTemplateHandler.cs
+++ b/source/Handlebars/IMissingPartialTemplateHandler.cs
@@ -1,0 +1,19 @@
+﻿using System.IO;
+
+namespace HandlebarsDotNet
+{
+    /// <summary>
+    /// Handler called when a partial template is missing. This allows silent error handling
+    /// or direct writing to the output stream.
+    /// </summary>
+    public interface IMissingPartialTemplateHandler
+    {
+        /// <summary>
+        /// Called when a partial template cannot be loaded.
+        /// </summary>
+        /// <param name="configuration">The current environment configuration.</param>
+        /// <param name="partialName">The name of the partial that was not found.</param>
+        /// <param name="textWriter">The output writer.</param>
+        void Handle(HandlebarsConfiguration configuration, string partialName, TextWriter textWriter);
+    }
+}

--- a/source/Handlebars/IPartialTemplateResolver.cs
+++ b/source/Handlebars/IPartialTemplateResolver.cs
@@ -1,0 +1,17 @@
+﻿namespace HandlebarsDotNet
+{
+    /// <summary>
+    /// Template resolver that gets called when an unknown partial is requested.
+    /// </summary>
+    public interface IPartialTemplateResolver
+    {
+        /// <summary>
+        /// Attempt to get and register a partial template.
+        /// </summary>
+        /// <param name="env"></param>
+        /// <param name="partialName">The name of the partial to load.</param>
+        /// <param name="templatePath"></param>
+        /// <returns>True if the partial was found and loaded successfully. Otherwise false.</returns>
+        bool TryRegisterPartial(IHandlebars env, string partialName, string templatePath);
+    }
+}


### PR DESCRIPTION
Added two features for partials:
  - Abstracted the missing template loader to allow a custom handler. The existing file system loader is still the default option, but users could define their own.
  - Added an optional handler for when templates fail to be found. Allows graceful and/or silent handling rather than throwing a full exception.