### PR TITLE
Added XML docs to NuGet package

### DIFF
--- a/source/Handlebars/Handlebars.csproj
+++ b/source/Handlebars/Handlebars.csproj
@@ -26,6 +26,7 @@
     <PackageTags>handlebars;mustache;templating;engine;compiler</PackageTags>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/rexm/Handlebars.Net</RepositoryUrl>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net452'">


### PR DESCRIPTION
Maybe there isn't much XML docs in the package, but now it's more useful as users will see the XML docs when using the API ;)

Preview:

![image](https://user-images.githubusercontent.com/5808377/62394836-b50bf300-b56e-11e9-8809-71ec68039b1c.png)
