### PR TITLE
#331: Support dynamic indexers

### DIFF
--- a/source/Handlebars.Test/BasicIntegrationTests.cs
+++ b/source/Handlebars.Test/BasicIntegrationTests.cs
@@ -221,6 +221,19 @@ false
             var result = template(data);
             Assert.Equal("Hello, Handlebars.Net!", result);
         }
+        
+        [Fact]
+        public void BasicPathArrayWithLiteralIndex()
+        {
+            var source = "{{#each names}}{{@root.names.[@index]}}{{/each}}";
+            var template = Handlebars.Compile(source);
+            var data = new
+            {
+                names = new[] { "Foo", "Handlebars.Net" }
+            };
+            var result = template(data);
+            Assert.Equal("FooHandlebars.Net", result);
+        }
 
         [Fact]
         public void BasicPathArrayChildPath()
@@ -548,6 +561,40 @@ false
             };
             var result = template(data);
             Assert.Equal("Hello, Handlebars.Net!", result);
+        }
+        
+        [Fact]
+        public void BasicPathDictionaryWithLiteralKey()
+        {
+            var source = "{{#each enumerateMe}}{{ @root.enumerateMe.@key }} {{/each}}";
+            var template = Handlebars.Compile(source);
+            var data = new
+            {
+                enumerateMe = new Dictionary<string, object>
+                {
+                    { "foo", "hello" },
+                    { "bar", "world" }
+                }
+            };
+            var result = template(data);
+            Assert.Equal("hello world ", result);
+        }
+        
+        [Fact]
+        public void BasicPathDictionaryWithLiteralKeyInSquareBrackets()
+        {
+            var source = "{{#each enumerateMe}}{{ @root.enumerateMe.[@key] }} {{/each}}";
+            var template = Handlebars.Compile(source);
+            var data = new
+            {
+                enumerateMe = new Dictionary<string, object>
+                {
+                    { "foo", "hello" },
+                    { "bar", "world" }
+                }
+            };
+            var result = template(data);
+            Assert.Equal("hello world ", result);
         }
 
         [Fact]

--- a/source/Handlebars/Compiler/Translation/Expression/MemberAccessors/DictionaryMemberAccessor.cs
+++ b/source/Handlebars/Compiler/Translation/Expression/MemberAccessors/DictionaryMemberAccessor.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections;
+
+namespace HandlebarsDotNet.Compiler
+{
+    internal class DictionaryMemberAccessor : MemberAccessor
+    {
+        public DictionaryMemberAccessor(CompilationContext compilationContext) : base(compilationContext)
+        {
+        }
+
+        public override bool TryAccessMember(BindingContext context, object instance, string memberName, out object result)
+        {
+            result = null;
+
+            // Check if the instance is IDictionary (ie, System.Collections.Hashtable)
+            if (!(instance is IDictionary dictionary)) return false;
+
+            memberName = ResolveMemberName(instance, memberName);
+            object key = ContainsVariable(memberName)
+                ? context.GetContextVariable(memberName.Substring(1))
+                : memberName;
+
+            // Only string keys supported - indexer takes an object, but no nice
+            // way to check if the hashtable check if it should be a different type.
+            if (!dictionary.Contains(key)) return false;
+
+            result = dictionary[key];
+            return true;
+        }
+    }
+}

--- a/source/Handlebars/Compiler/Translation/Expression/MemberAccessors/DynamicObjectMemberAccessor.cs
+++ b/source/Handlebars/Compiler/Translation/Expression/MemberAccessors/DynamicObjectMemberAccessor.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Dynamic;
+
+namespace HandlebarsDotNet.Compiler
+{
+    internal class DynamicObjectMemberAccessor : MemberAccessor
+    {
+        public DynamicObjectMemberAccessor(CompilationContext compilationContext) : base(compilationContext)
+        {
+        }
+
+        public override bool TryAccessMember(BindingContext context, object instance, string memberName, out object result)
+        {
+            result = null;
+
+            if (!(instance is IDynamicMetaObjectProvider metaObjectProvider)) return false;
+
+            memberName = ResolveMemberName(instance, memberName);
+            memberName = ContainsVariable(memberName)
+                ? context.GetContextVariable(memberName.Substring(1)) as string ?? memberName
+                : memberName;
+            
+            try
+            {
+                result = GetProperty(metaObjectProvider, memberName);
+                return result != null;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+        
+        private static object GetProperty(object target, string name)
+        {
+            var site = System.Runtime.CompilerServices.CallSite<Func<System.Runtime.CompilerServices.CallSite, object, object>>.Create(Microsoft.CSharp.RuntimeBinder.Binder.GetMember(0, name, target.GetType(), new[] { Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(0, null) }));
+            return site.Target(site, target);
+        }
+    }
+}

--- a/source/Handlebars/Compiler/Translation/Expression/MemberAccessors/EnumerableMemberAccessor.cs
+++ b/source/Handlebars/Compiler/Translation/Expression/MemberAccessors/EnumerableMemberAccessor.cs
@@ -1,0 +1,51 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace HandlebarsDotNet.Compiler
+{
+    internal class EnumerableMemberAccessor : MemberAccessor
+    {
+        private static readonly Regex IndexRegex = new Regex(@"^\[?(?<index>\d+)\]?$", RegexOptions.Compiled);
+
+        public EnumerableMemberAccessor(CompilationContext compilationContext) : base(compilationContext)
+        {
+        }
+
+        public override bool TryAccessMember(BindingContext context, object instance, string memberName, out object result)
+        {
+            result = null;
+
+            if (!(instance is IEnumerable<object> enumerable)) return false;
+
+            var match = IndexRegex.Match(memberName);
+            if (match.Success 
+                && match.Groups["index"].Success 
+                && int.TryParse(match.Groups["index"].Value, out var index)
+                && TryGetElement(enumerable, index, out result))
+            {
+                return true;
+            }
+
+            memberName = ResolveMemberName(instance, memberName);
+            if (!ContainsVariable(memberName)) return false;
+            
+            var contextVariable = context.GetContextVariable(memberName.Substring(1));
+            return (contextVariable is int indexFromContext || contextVariable is string indexString && int.TryParse(indexString, out indexFromContext))
+                   && TryGetElement(enumerable, indexFromContext, out result);
+        }
+
+        private static bool TryGetElement(IEnumerable<object> enumerable, int index, out object result)
+        {
+            result = null;
+            var elementAtIndex = enumerable.ElementAtOrDefault(index);
+            if (elementAtIndex == null)
+            {
+                return false;
+            }
+
+            result = elementAtIndex;
+            return true;
+        }
+    }
+}

--- a/source/Handlebars/Compiler/Translation/Expression/MemberAccessors/GenericDictionaryMemberAccessor.cs
+++ b/source/Handlebars/Compiler/Translation/Expression/MemberAccessors/GenericDictionaryMemberAccessor.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace HandlebarsDotNet.Compiler
+{
+    internal class GenericDictionaryMemberAccessor : MemberAccessor
+    {
+        public GenericDictionaryMemberAccessor(CompilationContext compilationContext) : base(compilationContext)
+        {
+        }
+
+        public override bool TryAccessMember(BindingContext context, object instance, string memberName, out object result)
+        {
+            result = null;
+
+            // Check if the instance is IDictionary<,>
+            var instanceType = instance.GetType();
+            var iDictInstance = FirstGenericDictionaryTypeInstance(instanceType);
+            if (iDictInstance == null) return false;
+
+            var genericArgs = iDictInstance.GetGenericArguments();
+            memberName = ResolveMemberName(instance, memberName);
+            object key = ContainsVariable(memberName)
+                ? context.GetContextVariable(memberName.Substring(1))
+                : memberName;
+
+            if (genericArgs.Length > 0 && genericArgs[0] != key.GetType())
+            {
+                // Dictionary key type isn't a string, so attempt to convert.
+                try
+                {
+                    key = Convert.ChangeType(key, genericArgs[0], CultureInfo.CurrentCulture);
+                }
+                catch (Exception)
+                {
+                    // Can't convert to key type.
+                    return false;
+                }
+            }
+
+            var containsKeyMethod = GetMethod(instanceType, "ContainsKey");
+            if (containsKeyMethod == null)
+            {
+                throw new MethodAccessException("Method ContainsKey not found");
+            }
+
+            var parameters = new[] {key};
+            if (!(bool) containsKeyMethod.Invoke(instance, parameters))
+                return false; // Key doesn't exist.
+
+            var itemProperty = GetMethod(instanceType, "get_Item");
+            if (itemProperty == null)
+            {
+                throw new MethodAccessException("Property Item not found");
+            }
+
+            result = itemProperty.Invoke(instance, parameters);
+            return true;
+        }
+
+        private static MethodInfo GetMethod(Type instanceType, string methodName)
+        {
+            var methodInfo = instanceType.GetMethod(methodName);
+
+            if (methodInfo == null)
+            {
+                // Support implicit interface impl.
+                methodInfo = instanceType.GetTypeInfo().DeclaredMethods.FirstOrDefault(m =>
+                    m.IsPrivate && m.Name.StartsWith("System.Collections.Generic.IDictionary") &&
+                    m.Name.EndsWith(methodName));
+            }
+
+            return methodInfo;
+        }
+
+        private static Type FirstGenericDictionaryTypeInstance(Type instanceType)
+        {
+            return instanceType.GetInterfaces()
+                .FirstOrDefault(i =>
+#if netstandard
+                    i.GetTypeInfo().IsGenericType
+#else
+                    i.IsGenericType
+#endif
+                    &&
+                    (
+                        i.GetGenericTypeDefinition() == typeof(IDictionary<,>)
+                    )
+                );
+        }
+    }
+}

--- a/source/Handlebars/Compiler/Translation/Expression/MemberAccessors/MemberAccessor.cs
+++ b/source/Handlebars/Compiler/Translation/Expression/MemberAccessors/MemberAccessor.cs
@@ -1,0 +1,30 @@
+﻿namespace HandlebarsDotNet.Compiler
+{
+    internal abstract class MemberAccessor
+    {
+        private readonly CompilationContext _compilationContext;
+
+        protected MemberAccessor(CompilationContext compilationContext)
+        {
+            _compilationContext = compilationContext;
+        }
+        
+        public abstract bool TryAccessMember(BindingContext context, object instance, string memberName, out object result);
+
+        protected string ResolveMemberName(object instance, string memberName)
+        {
+            var resolver = _compilationContext.Configuration.ExpressionNameResolver;
+            memberName = resolver != null
+                ? resolver.ResolveExpressionName(instance, memberName)
+                : memberName;
+            
+            memberName = memberName.Trim('[', ']'); // Ensure square brackets removed.
+            return memberName;
+        }
+        
+        protected static bool ContainsVariable(string segment)
+        {
+            return segment.StartsWith("@");
+        }
+    }
+}

--- a/source/Handlebars/Compiler/Translation/Expression/MemberAccessors/ReflectionMemberAccessor.cs
+++ b/source/Handlebars/Compiler/Translation/Expression/MemberAccessors/ReflectionMemberAccessor.cs
@@ -1,0 +1,41 @@
+﻿using System.Linq;
+using System.Reflection;
+
+namespace HandlebarsDotNet.Compiler
+{
+    internal class ReflectionMemberAccessor : MemberAccessor
+    {
+        public ReflectionMemberAccessor(CompilationContext compilationContext) : base(compilationContext)
+        {
+        }
+
+        public override bool TryAccessMember(BindingContext context, object instance, string memberName, out object result)
+        {
+            result = null;
+
+            var instanceType = instance.GetType();
+            memberName = ResolveMemberName(instance, memberName);
+            var members = instanceType.GetMember(memberName, BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
+
+            if (members.Length == 0) return false;
+
+            var preferredMember = members.Length > 1
+                ? members.FirstOrDefault(m => m.Name == memberName) ?? members[0]
+                : members[0];
+            
+            switch (preferredMember)
+            {
+                case PropertyInfo propertyInfo:
+                    result = propertyInfo.GetValue(instance, null);
+                    return true;
+                
+                case FieldInfo fieldInfo:
+                    result = fieldInfo.GetValue(instance);
+                    return true;
+                
+                default:
+                    return false;
+            }
+        }
+    }
+}

--- a/source/Handlebars/Compiler/Translation/Expression/PathBinder.cs
+++ b/source/Handlebars/Compiler/Translation/Expression/PathBinder.cs
@@ -1,18 +1,14 @@
 using System;
-using System.Collections;
-using System.Linq;
 using System.Linq.Expressions;
-using System.Reflection;
 using System.IO;
-using System.Dynamic;
-using System.Collections.Generic;
-using System.Text.RegularExpressions;
-using System.Globalization;
+using System.Reflection;
 
 namespace HandlebarsDotNet.Compiler
 {
     internal class PathBinder : HandlebarsExpressionVisitor
     {
+        private readonly MemberAccessor[] _memberAccessors;
+        
         public static Expression Bind(Expression expr, CompilationContext context)
         {
             return new PathBinder(context).Visit(expr);
@@ -21,6 +17,14 @@ namespace HandlebarsDotNet.Compiler
         private PathBinder(CompilationContext context)
             : base(context)
         {
+            _memberAccessors = new MemberAccessor[]
+            {
+                new EnumerableMemberAccessor(context), 
+                new DynamicObjectMemberAccessor(context), 
+                new GenericDictionaryMemberAccessor(context), 
+                new DictionaryMemberAccessor(context), 
+                new ReflectionMemberAccessor(context)
+            };
         }
 
         protected override Expression VisitStatementExpression(StatementExpression sex)
@@ -88,229 +92,68 @@ namespace HandlebarsDotNet.Compiler
                         throw new HandlebarsCompilerException("Path expression tried to reference parent of root");
                     }
                     instance = context.Value;
+                    continue;
                 }
-                else
+
+                var objectPropertiesChain = containsVariable ? "@" + segment : segment;
+
+                foreach (var memberName in objectPropertiesChain.Split('.'))
                 {
-                    var objectPropertiesChain = containsVariable ? "@" + segment : segment;
+                    instance = ResolveValue(context, instance, memberName);
 
-                    foreach (var memberName in objectPropertiesChain.Split('.'))
+                    if (!(instance is UndefinedBindingResult)) continue;
+
+                    if (hashParameters == null || hashParameters.ContainsKey(memberName) || context.ParentContext == null)
                     {
-                        instance = ResolveValue(context, instance, memberName);
-
-                        if (!(instance is UndefinedBindingResult))
-                            continue;
-
-                        if (hashParameters == null || hashParameters.ContainsKey(memberName) || context.ParentContext == null)
-                        {
-                            if (CompilationContext.Configuration.ThrowOnUnresolvedBindingExpression)
-                                throw new HandlebarsUndefinedBindingException(path, (instance as UndefinedBindingResult).Value);
-                            return instance;
-                        }
-
-                        instance = ResolveValue(context.ParentContext, context.ParentContext.Value, memberName);
-                        if (instance is UndefinedBindingResult)
-                        {
-                            if (CompilationContext.Configuration.ThrowOnUnresolvedBindingExpression)
-                                throw new HandlebarsUndefinedBindingException(path, (instance as UndefinedBindingResult).Value);
-                            return instance;
-                        }
+                        if (CompilationContext.Configuration.ThrowOnUnresolvedBindingExpression)
+                            throw new HandlebarsUndefinedBindingException(path, (instance as UndefinedBindingResult).Value);
+                        return instance;
                     }
+
+                    instance = ResolveValue(context.ParentContext, context.ParentContext.Value, memberName);
+                    if (!(instance is UndefinedBindingResult undefinedBindingResult)) continue;
+                    
+                    if (CompilationContext.Configuration.ThrowOnUnresolvedBindingExpression)
+                        throw new HandlebarsUndefinedBindingException(path, undefinedBindingResult.Value);
+                        
+                    return undefinedBindingResult;
                 }
             }
+            
             return instance;
         }
 
         private object ResolveValue(BindingContext context, object instance, string segment)
         {
-            object resolvedValue = new UndefinedBindingResult(segment, CompilationContext.Configuration);
-            if (segment.StartsWith("@"))
-            {
-                var contextValue = context.GetContextVariable(segment.Substring(1));
-                if (contextValue != null)
-                {
-                    resolvedValue = contextValue;
-                }
-            }
-            else if (segment == "this" || segment == string.Empty)
-            {
-                resolvedValue = instance;
-            }
-            else
-            {
-                resolvedValue = AccessMember(instance, segment);
-            }
-            return resolvedValue;
+            if (string.IsNullOrEmpty(segment) || segment == "this") return instance;
+            
+            if (!segment.StartsWith("@")) return AccessMember(context, instance, segment);
+            
+            var contextValue = context.GetContextVariable(segment.Substring(1));
+            if (contextValue == null) return new UndefinedBindingResult(segment, CompilationContext.Configuration);
+            if (!(contextValue is string value)) return contextValue;
+                
+            var member = AccessMember(context, instance, value);
+            return member is UndefinedBindingResult 
+                ? contextValue 
+                : member;
         }
 
-        private static readonly Regex IndexRegex = new Regex(@"^\[?(?<index>\d+)\]?$", RegexOptions.None);
-
-        private object AccessMember(object instance, string memberName)
+        private object AccessMember(BindingContext context, object instance, string memberName)
         {
-            if (instance == null)
-                return new UndefinedBindingResult(memberName, CompilationContext.Configuration);
+            var undefinedBindingResult = new UndefinedBindingResult(memberName, CompilationContext.Configuration);
+            
+            if (instance == null) return undefinedBindingResult;
 
-            var enumerable = instance as IEnumerable<object>;
-            if (enumerable != null)
+            foreach (var memberAccessor in _memberAccessors)
             {
-                var match = IndexRegex.Match(memberName);
-                if (match.Success)
+                if (memberAccessor.TryAccessMember(context, instance, memberName, out var result))
                 {
-                    int index;
-                    if (match.Groups["index"].Success == false || int.TryParse(match.Groups["index"].Value, out index) == false)
-                    {
-                        return new UndefinedBindingResult(memberName, CompilationContext.Configuration);
-                    }
-
-                    var result = enumerable.ElementAtOrDefault(index);
-
-                    return result ?? new UndefinedBindingResult(memberName, CompilationContext.Configuration);
-                }
-            }
-            var resolvedMemberName = ResolveMemberName(instance, memberName);
-            var instanceType = instance.GetType();
-            //crude handling for dynamic objects that don't have metadata
-            if (typeof(IDynamicMetaObjectProvider).IsAssignableFrom(instanceType))
-            {
-                try
-                {
-                    var key = resolvedMemberName.Trim('[', ']'); // Ensure square brackets removed
-                    var result = GetProperty(instance, key);
-                    if (result == null)
-                        return new UndefinedBindingResult(key, CompilationContext.Configuration);
-
                     return result;
                 }
-                catch
-                {
-                    return new UndefinedBindingResult(resolvedMemberName, CompilationContext.Configuration);
-                }
             }
 
-
-            // Check if the instance is IDictionary<,>
-            var iDictInstance = FirstGenericDictionaryTypeInstance(instanceType);
-            if (iDictInstance != null)
-            {
-                var genericArgs = iDictInstance.GetGenericArguments();
-                object key = resolvedMemberName.Trim('[', ']');    // Ensure square brackets removed.
-                if (genericArgs.Length > 0)
-                {
-                    // Dictionary key type isn't a string, so attempt to convert.
-                    if (genericArgs[0] != typeof(string))
-                    {
-                        try
-                        {
-                            key = Convert.ChangeType(key, genericArgs[0], CultureInfo.CurrentCulture);
-                        }
-                        catch (Exception)
-                        {
-                            // Can't convert to key type.
-                            return new UndefinedBindingResult(resolvedMemberName, CompilationContext.Configuration);
-                        }
-                    }
-                }
-
-                var containsKeyMethod = GetDictionaryMethod(instanceType, "ContainsKey");
-
-                if (containsKeyMethod == null)
-                {
-                    throw new MethodAccessException("Method ContainsKey not found");
-                }
-
-                if ((bool)containsKeyMethod.Invoke(instance, new[] { key }))
-                {
-                    var itemProperty = GetDictionaryMethod(instanceType, "get_Item");
-                    if (itemProperty == null)
-                    {
-                        throw new MethodAccessException("Property Item not found");
-                    }
-
-                    return itemProperty.Invoke(instance, new[] { key });
-                }
-                else
-                {
-                    // Key doesn't exist.
-                    return new UndefinedBindingResult(resolvedMemberName, CompilationContext.Configuration);
-                }
-            }
-            // Check if the instance is IDictionary (ie, System.Collections.Hashtable)
-            if (typeof(IDictionary).IsAssignableFrom(instanceType))
-            {
-                var key = resolvedMemberName.Trim('[', ']');    // Ensure square brackets removed.
-                // Only string keys supported - indexer takes an object, but no nice
-                // way to check if the hashtable check if it should be a different type.
-                return ((IDictionary)instance)[key];
-            }
-
-            var members = instanceType.GetMember(resolvedMemberName, BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
-            MemberInfo preferredMember;
-            if (members.Length == 0)
-            {
-                return new UndefinedBindingResult(resolvedMemberName, CompilationContext.Configuration);
-            }
-            else if (members.Length > 1)
-            {
-                preferredMember = members.FirstOrDefault(m => m.Name == resolvedMemberName) ?? members[0];
-            }
-            else
-            {
-                preferredMember = members[0];
-            }
-
-            var propertyInfo = preferredMember as PropertyInfo;
-            if (propertyInfo != null)
-            {
-                var propertyValue = propertyInfo.GetValue(instance, null);
-                return propertyValue;
-            }
-            if (preferredMember is FieldInfo)
-            {
-                var fieldValue = ((FieldInfo)preferredMember).GetValue(instance);
-                return fieldValue;
-            }
-            return new UndefinedBindingResult(resolvedMemberName, CompilationContext.Configuration);
-        }
-
-
-        private static MethodInfo GetDictionaryMethod(Type instanceType, string methodName)
-        {
-            var methodInfo = instanceType.GetMethod(methodName);
-
-            if (methodInfo == null)
-            {
-                // Support implicit interface impl.
-                methodInfo = instanceType.GetTypeInfo().DeclaredMethods.FirstOrDefault(m => m.IsPrivate && m.Name.StartsWith("System.Collections.Generic.IDictionary") && m.Name.EndsWith(methodName));
-            }
-
-            return methodInfo;
-        }
-
-        static Type FirstGenericDictionaryTypeInstance(Type instanceType)
-        {
-            return instanceType.GetInterfaces()
-                .FirstOrDefault(i =>
-#if netstandard
-                    i.GetTypeInfo().IsGenericType
-#else
-                    i.IsGenericType
-#endif
-                    &&
-                    (
-                        i.GetGenericTypeDefinition() == typeof(IDictionary<,>)
-                    )
-                );
-        }
-
-        private static object GetProperty(object target, string name)
-        {
-            var site = System.Runtime.CompilerServices.CallSite<Func<System.Runtime.CompilerServices.CallSite, object, object>>.Create(Microsoft.CSharp.RuntimeBinder.Binder.GetMember(0, name, target.GetType(), new[] { Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(0, null) }));
-            return site.Target(site, target);
-        }
-
-        private string ResolveMemberName(object instance, string memberName)
-        {
-            var resolver = CompilationContext.Configuration.ExpressionNameResolver;
-            return resolver != null ? resolver.ResolveExpressionName(instance, memberName) : memberName;
+            return undefinedBindingResult;
         }
     }
 }


### PR DESCRIPTION
In this PR:
- fix for #331 
- refactoring of `PathBinder`: split `AccessMember` into multiple classes based on access type