### PR TITLE
Added Tests for use in discoverring issue with escape characters

### DIFF
--- a/source/Handlebars.Test/Handlebars.Test.csproj
+++ b/source/Handlebars.Test/Handlebars.Test.csproj
@@ -19,8 +19,11 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net461'">

--- a/source/Handlebars.Test/Handlebars.Test.csproj
+++ b/source/Handlebars.Test/Handlebars.Test.csproj
@@ -2,12 +2,9 @@
 
   <PropertyGroup>
     <DebugType>full</DebugType>
-    <TargetFrameworks>net461;netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)'=='netcoreapp1.1'">
-    <DefineConstants>$(DefineConstants);netstandard</DefineConstants>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)'=='netcoreapp2.0'">
     <DefineConstants>$(DefineConstants);netstandard</DefineConstants>
   </PropertyGroup>
@@ -25,16 +22,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)'=='net461'">
-    <PackageReference Include="CsQuery" Version="1.3.4" />
-    <PackageReference Include="Microsoft.AspNet.WebPages" Version="3.2.3" />
-    <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp1.1'">
-    <PackageReference Include="System.Collections.NonGeneric" Version="4.3.0" />
-  </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp2.0'">
     <PackageReference Include="System.Collections.NonGeneric" Version="4.3.0" />
@@ -47,10 +34,6 @@
 
   <ItemGroup>
     <Content Include="ViewEngine\**\*.hbs" CopyToOutputDirectory="PreserveNewest" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp1.1'">
-    <Compile Remove="**\CasparTests.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Handlebars.Test/JsonIntegrationTests.cs
+++ b/source/Handlebars.Test/JsonIntegrationTests.cs
@@ -1,0 +1,107 @@
+using Xunit;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Dynamic;
+using HandlebarsDotNet.Compiler;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System.Runtime.Serialization;
+
+namespace HandlebarsDotNet.Test
+{
+	[DataContract]
+	public class TestJSONObject
+	{
+		[DataMember]
+		public virtual string Description { get; set; }
+
+		[DataMember]
+		public virtual string Name { get; set; }
+
+
+		[DataMember]
+		public virtual TestJSONObject Test{ get; set; }
+	}
+	public class JsonIntegrationTests
+	{
+		[Fact]
+		public void BasicJSON()
+		{
+			var json = new TestJSONObject()
+			{
+				Name = "Thing - {{Thing.Name}}",
+				Description = "A description of {{Thing.Name}}",
+				Test = new TestJSONObject()
+				{
+					Test = new TestJSONObject()
+					{
+						Name = "{{Thing.Name}}"
+					}
+				}
+			};
+
+			var source = JsonConvert.SerializeObject(json);
+
+			var template = Handlebars.Compile(source);
+
+			var data = new
+			{
+				Thing = new
+				{
+					Name = "Handlebars.Net"
+				}
+			};
+
+			var result = template(data);
+
+			Assert.NotNull(result);
+
+			var resultJson = JsonConvert.DeserializeObject<TestJSONObject>(result);
+
+			Assert.Equal($"Thing - {data.Thing.Name}", resultJson.Name);
+			Assert.Equal($"A description of {data.Thing.Name}", resultJson.Description);
+			Assert.Equal(data.Thing.Name, resultJson.Test.Test.Name);
+		}
+
+		[Fact]
+		public void BasicWwithEscapeJSON()
+		{
+			var json = new TestJSONObject()
+			{
+				Name = "Thing - {{Thing.Name}}",
+				Description = "**\\*.{{Thing.Name}}",
+				Test = new TestJSONObject()
+				{
+					Test = new TestJSONObject()
+					{
+						Name = "\"{{Thing.Name}}\""
+					}
+				}
+			};
+
+			var source = JsonConvert.SerializeObject(json);
+
+			var template = Handlebars.Compile(source);
+
+			var data = new
+			{
+				Thing = new
+				{
+					Name = "Handlebars.Net"
+				}
+			};
+
+			var result = template(data);
+
+			Assert.NotNull(result);
+
+			var resultJson = JsonConvert.DeserializeObject<TestJSONObject>(result);
+
+			Assert.Equal($"Thing - {data.Thing.Name}", resultJson.Name);
+			Assert.Equal($@"**\*.{data.Thing.Name}", resultJson.Description);
+			Assert.Equal($@"""{data.Thing.Name}""", resultJson.Test.Test.Name);
+		}
+	}
+}
+

--- a/source/Handlebars/Compiler/Lexer/Tokenizer.cs
+++ b/source/Handlebars/Compiler/Lexer/Tokenizer.cs
@@ -6,182 +6,189 @@ using System.Text;
 
 namespace HandlebarsDotNet.Compiler.Lexer
 {
-    internal class Tokenizer
-    {
-        private readonly HandlebarsConfiguration _configuration;
+	internal class Tokenizer
+	{
+		private readonly HandlebarsConfiguration _configuration;
 
-        private static Parser _wordParser = new WordParser();
-        private static Parser _literalParser = new LiteralParser();
-        private static Parser _commentParser = new CommentParser();
-        private static Parser _partialParser = new PartialParser();
-        private static Parser _blockWordParser = new BlockWordParser();
-        //TODO: structure parser
+		private static Parser _wordParser = new WordParser();
+		private static Parser _literalParser = new LiteralParser();
+		private static Parser _commentParser = new CommentParser();
+		private static Parser _partialParser = new PartialParser();
+		private static Parser _blockWordParser = new BlockWordParser();
+		//TODO: structure parser
 
-        public Tokenizer(HandlebarsConfiguration configuration)
-        {
-            _configuration = configuration;
-        }
+		public Tokenizer(HandlebarsConfiguration configuration)
+		{
+			_configuration = configuration;
+		}
 
-        public IEnumerable<Token> Tokenize(TextReader source)
-        {
-            try
-            {
-                return Parse(source);
-            }
-            catch (Exception ex)
-            {
-                throw new HandlebarsParserException("An unhandled exception occurred while trying to compile the template", ex);
-            }
-        }
+		public IEnumerable<Token> Tokenize(TextReader source)
+		{
+			try
+			{
+				return Parse(source);
+			}
+			catch (Exception ex)
+			{
+				throw new HandlebarsParserException("An unhandled exception occurred while trying to compile the template", ex);
+			}
+		}
 
-        private IEnumerable<Token> Parse(TextReader source)
-        {
-            bool inExpression = false;
-            bool trimWhitespace = false;
-            var buffer = new StringBuilder();
-            var node = source.Read();
-            while (true)
-            {
-                if (node == -1)
-                {
-                    if (buffer.Length > 0)
-                    {
-                        if (inExpression)
-                        {
-                            throw new InvalidOperationException("Reached end of template before expression was closed");
-                        }
-                        else
-                        {
-                            yield return Token.Static(buffer.ToString());
-                        }
-                    }
-                    break;
-                }
-                if (inExpression)
-                {
-                    if ((char)node == '(')
-                    {
-                        yield return Token.StartSubExpression();
-                    }
+		private IEnumerable<Token> Parse(TextReader source)
+		{
+			bool inExpression = false;
+			bool trimWhitespace = false;
+			var buffer = new StringBuilder();
+			var node = source.Read();
+			while (true)
+			{
+				if (node == -1)
+				{
+					if (buffer.Length > 0)
+					{
+						if (inExpression)
+						{
+							throw new InvalidOperationException("Reached end of template before expression was closed");
+						}
+						else
+						{
+							yield return Token.Static(buffer.ToString());
+						}
+					}
+					break;
+				}
+				if (inExpression)
+				{
+					if ((char)node == '(')
+					{
+						yield return Token.StartSubExpression();
+					}
 
-                    Token token = null;
-                    token = token ?? _wordParser.Parse(source);
-                    token = token ?? _literalParser.Parse(source);
-                    token = token ?? _commentParser.Parse(source);
-                    token = token ?? _partialParser.Parse(source);
-                    token = token ?? _blockWordParser.Parse(source);
+					Token token = null;
+					token = token ?? _wordParser.Parse(source);
+					token = token ?? _literalParser.Parse(source);
+					token = token ?? _commentParser.Parse(source);
+					token = token ?? _partialParser.Parse(source);
+					token = token ?? _blockWordParser.Parse(source);
 
-                    if (token != null)
-                    {
-                        yield return token;
+					if (token != null)
+					{
+						yield return token;
 
-                        if ((char)source.Peek() == '=')
-                        {
-                            source.Read();
-                            yield return Token.Assignment();
-                            continue;
-                        }
-                    }
-                    if ((char)node == '}' && (char)source.Read() == '}')
-                    {
-                        bool escaped = true;
-                        bool raw = false;
-                        if ((char)source.Peek() == '}')
-                        {
-                            node = source.Read();
-                            escaped = false;
-                        }
-                        if ((char)source.Peek() == '}')
-                        {
-                            node = source.Read();
-                            raw = true;
-                        }
-                        node = source.Read();
-                        yield return Token.EndExpression(escaped, trimWhitespace, raw);
-                        inExpression = false;
-                    }
-                    else if ((char)node == ')')
-                    {
-                        node = source.Read();
-                        yield return Token.EndSubExpression();
-                    }
-                    else if (char.IsWhiteSpace((char)node) || char.IsWhiteSpace((char)source.Peek()))
-                    {
-                        node = source.Read();
-                    }
-                    else if ((char)node == '~')
-                    {
-                        node = source.Read();
-                        trimWhitespace = true;
-                    }
-                    else
-                    {
-                        if (token == null)
-                        {
-                            
-                            throw new HandlebarsParserException("Reached unparseable token in expression: " + source.ReadLine());
-                        }
-                        node = source.Read();
-                    }
-                }
-                else
-                {
-                    if ((char)node == '\\' && (char)source.Peek() == '\\')
-                    {
-                        source.Read();
-                        buffer.Append('\\');
-                        node = source.Read();
-                    }
-                    else if ((char)node == '\\' && (char)source.Peek() == '{')
-                    {
-                        source.Read();
-                        if ((char)source.Peek() == '{')
-                        {
-                            source.Read();
-                            buffer.Append('{', 2);
-                        }
-                        else
-                        {
-                            buffer.Append("\\{");
-                        }
-                        node = source.Read();
-                    }
-                    else if ((char)node == '{' && (char)source.Peek() == '{')
-                    {
-                        bool escaped = true;
-                        bool raw = false;
-                        trimWhitespace = false;
-                        node = source.Read();
-                        if ((char)source.Peek() == '{')
-                        {
-                            node = source.Read();
-                            escaped = false;
-                        }
-                        if ((char)source.Peek() == '{')
-                        {
-                            node = source.Read();
-                            raw = true;
-                        }
-                        if ((char)source.Peek() == '~')
-                        {
-                            source.Read();
-                            node = source.Peek();
-                            trimWhitespace = true;
-                        }
-                        yield return Token.Static(buffer.ToString());
-                        yield return Token.StartExpression(escaped, trimWhitespace, raw);
-                        trimWhitespace = false;
-                        buffer = new StringBuilder();
-                        inExpression = true;
-                    }
-                    else
-                    {
-                        buffer.Append((char)node);
-                        node = source.Read();
-                    }
-                }
-            }
-        }
-    }
+						if ((char)source.Peek() == '=')
+						{
+							source.Read();
+							yield return Token.Assignment();
+							continue;
+						}
+					}
+					if ((char)node == '}' && (char)source.Read() == '}')
+					{
+						bool escaped = true;
+						bool raw = false;
+						if ((char)source.Peek() == '}')
+						{
+							node = source.Read();
+							escaped = false;
+						}
+						if ((char)source.Peek() == '}')
+						{
+							node = source.Read();
+							raw = true;
+						}
+						node = source.Read();
+						yield return Token.EndExpression(escaped, trimWhitespace, raw);
+						inExpression = false;
+					}
+					else if ((char)node == ')')
+					{
+						node = source.Read();
+						yield return Token.EndSubExpression();
+					}
+					else if (char.IsWhiteSpace((char)node) || char.IsWhiteSpace((char)source.Peek()))
+					{
+						node = source.Read();
+					}
+					else if ((char)node == '~')
+					{
+						node = source.Read();
+						trimWhitespace = true;
+					}
+					else
+					{
+						if (token == null)
+						{
+
+							throw new HandlebarsParserException("Reached unparseable token in expression: " + source.ReadLine());
+						}
+						node = source.Read();
+					}
+				}
+				else
+				{
+					if ((char)node == '\\' && (char)source.Peek() == '\\')
+					{
+						source.Read();
+						buffer.Append('\\');
+
+						if ((char)source.Peek() == '{')
+							node = source.Read();
+					}
+					else if ((char)node == '\\' && (char)source.Peek() == '{')
+					{
+						source.Read();
+						if ((char)source.Peek() == '{')
+						{
+							source.Read();
+							buffer.Append('{', 2);
+						}
+						else
+						{
+							buffer.Append("\\{");
+						}
+						node = source.Read();
+					}
+					else if ((char)node == '{' && (char)source.Peek() == '{')
+					{
+						bool escaped = true;
+						bool raw = false;
+						trimWhitespace = false;
+						node = source.Read();
+						if ((char)source.Peek() == '{')
+						{
+							node = source.Read();
+							escaped = false;
+						}
+						if ((char)source.Peek() == '{')
+						{
+							node = source.Read();
+							raw = true;
+						}
+						if ((char)source.Peek() == '~')
+						{
+							source.Read();
+							node = source.Peek();
+							trimWhitespace = true;
+						}
+						yield return Token.Static(buffer.ToString());
+						yield return Token.StartExpression(escaped, trimWhitespace, raw);
+						trimWhitespace = false;
+						buffer = new StringBuilder();
+						inExpression = true;
+					}
+					else
+					{
+						buffer.Append((char)node);
+						node = source.Read();
+					}
+				}
+			}
+		}
+
+		private bool handleEscapeDepth(int node, TextReader source, StringBuilder buffer, bool hasDepth)
+		{
+			return false;
+		}
+	}
 }
 

--- a/source/Handlebars/Compiler/Lexer/Tokenizer.cs
+++ b/source/Handlebars/Compiler/Lexer/Tokenizer.cs
@@ -6,189 +6,184 @@ using System.Text;
 
 namespace HandlebarsDotNet.Compiler.Lexer
 {
-	internal class Tokenizer
-	{
-		private readonly HandlebarsConfiguration _configuration;
+    internal class Tokenizer
+    {
+        private readonly HandlebarsConfiguration _configuration;
 
-		private static Parser _wordParser = new WordParser();
-		private static Parser _literalParser = new LiteralParser();
-		private static Parser _commentParser = new CommentParser();
-		private static Parser _partialParser = new PartialParser();
-		private static Parser _blockWordParser = new BlockWordParser();
-		//TODO: structure parser
+        private static Parser _wordParser = new WordParser();
+        private static Parser _literalParser = new LiteralParser();
+        private static Parser _commentParser = new CommentParser();
+        private static Parser _partialParser = new PartialParser();
+        private static Parser _blockWordParser = new BlockWordParser();
+        //TODO: structure parser
 
-		public Tokenizer(HandlebarsConfiguration configuration)
-		{
-			_configuration = configuration;
-		}
+        public Tokenizer(HandlebarsConfiguration configuration)
+        {
+            _configuration = configuration;
+        }
 
-		public IEnumerable<Token> Tokenize(TextReader source)
-		{
-			try
-			{
-				return Parse(source);
-			}
-			catch (Exception ex)
-			{
-				throw new HandlebarsParserException("An unhandled exception occurred while trying to compile the template", ex);
-			}
-		}
+        public IEnumerable<Token> Tokenize(TextReader source)
+        {
+            try
+            {
+                return Parse(source);
+            }
+            catch (Exception ex)
+            {
+                throw new HandlebarsParserException("An unhandled exception occurred while trying to compile the template", ex);
+            }
+        }
 
-		private IEnumerable<Token> Parse(TextReader source)
-		{
-			bool inExpression = false;
-			bool trimWhitespace = false;
-			var buffer = new StringBuilder();
-			var node = source.Read();
-			while (true)
-			{
-				if (node == -1)
-				{
-					if (buffer.Length > 0)
-					{
-						if (inExpression)
-						{
-							throw new InvalidOperationException("Reached end of template before expression was closed");
-						}
-						else
-						{
-							yield return Token.Static(buffer.ToString());
-						}
-					}
-					break;
-				}
-				if (inExpression)
-				{
-					if ((char)node == '(')
-					{
-						yield return Token.StartSubExpression();
-					}
+        private IEnumerable<Token> Parse(TextReader source)
+        {
+            bool inExpression = false;
+            bool trimWhitespace = false;
+            var buffer = new StringBuilder();
+            var node = source.Read();
+            while (true)
+            {
+                if (node == -1)
+                {
+                    if (buffer.Length > 0)
+                    {
+                        if (inExpression)
+                        {
+                            throw new InvalidOperationException("Reached end of template before expression was closed");
+                        }
+                        else
+                        {
+                            yield return Token.Static(buffer.ToString());
+                        }
+                    }
+                    break;
+                }
+                if (inExpression)
+                {
+                    if ((char)node == '(')
+                    {
+                        yield return Token.StartSubExpression();
+                    }
 
-					Token token = null;
-					token = token ?? _wordParser.Parse(source);
-					token = token ?? _literalParser.Parse(source);
-					token = token ?? _commentParser.Parse(source);
-					token = token ?? _partialParser.Parse(source);
-					token = token ?? _blockWordParser.Parse(source);
+                    Token token = null;
+                    token = token ?? _wordParser.Parse(source);
+                    token = token ?? _literalParser.Parse(source);
+                    token = token ?? _commentParser.Parse(source);
+                    token = token ?? _partialParser.Parse(source);
+                    token = token ?? _blockWordParser.Parse(source);
 
-					if (token != null)
-					{
-						yield return token;
+                    if (token != null)
+                    {
+                        yield return token;
 
-						if ((char)source.Peek() == '=')
-						{
-							source.Read();
-							yield return Token.Assignment();
-							continue;
-						}
-					}
-					if ((char)node == '}' && (char)source.Read() == '}')
-					{
-						bool escaped = true;
-						bool raw = false;
-						if ((char)source.Peek() == '}')
-						{
-							node = source.Read();
-							escaped = false;
-						}
-						if ((char)source.Peek() == '}')
-						{
-							node = source.Read();
-							raw = true;
-						}
-						node = source.Read();
-						yield return Token.EndExpression(escaped, trimWhitespace, raw);
-						inExpression = false;
-					}
-					else if ((char)node == ')')
-					{
-						node = source.Read();
-						yield return Token.EndSubExpression();
-					}
-					else if (char.IsWhiteSpace((char)node) || char.IsWhiteSpace((char)source.Peek()))
-					{
-						node = source.Read();
-					}
-					else if ((char)node == '~')
-					{
-						node = source.Read();
-						trimWhitespace = true;
-					}
-					else
-					{
-						if (token == null)
-						{
+                        if ((char)source.Peek() == '=')
+                        {
+                            source.Read();
+                            yield return Token.Assignment();
+                            continue;
+                        }
+                    }
+                    if ((char)node == '}' && (char)source.Read() == '}')
+                    {
+                        bool escaped = true;
+                        bool raw = false;
+                        if ((char)source.Peek() == '}')
+                        {
+                            node = source.Read();
+                            escaped = false;
+                        }
+                        if ((char)source.Peek() == '}')
+                        {
+                            node = source.Read();
+                            raw = true;
+                        }
+                        node = source.Read();
+                        yield return Token.EndExpression(escaped, trimWhitespace, raw);
+                        inExpression = false;
+                    }
+                    else if ((char)node == ')')
+                    {
+                        node = source.Read();
+                        yield return Token.EndSubExpression();
+                    }
+                    else if (char.IsWhiteSpace((char)node) || char.IsWhiteSpace((char)source.Peek()))
+                    {
+                        node = source.Read();
+                    }
+                    else if ((char)node == '~')
+                    {
+                        node = source.Read();
+                        trimWhitespace = true;
+                    }
+                    else
+                    {
+                        if (token == null)
+                        {
+                            
+                            throw new HandlebarsParserException("Reached unparseable token in expression: " + source.ReadLine());
+                        }
+                        node = source.Read();
+                    }
+                }
+                else
+                {
+                    if ((char)node == '\\' && (char)source.Peek() == '\\')
+                    {
+                        source.Read();
+                        buffer.Append('\\');
 
-							throw new HandlebarsParserException("Reached unparseable token in expression: " + source.ReadLine());
-						}
-						node = source.Read();
-					}
-				}
-				else
-				{
-					if ((char)node == '\\' && (char)source.Peek() == '\\')
-					{
-						source.Read();
-						buffer.Append('\\');
-
-						if ((char)source.Peek() == '{')
-							node = source.Read();
-					}
-					else if ((char)node == '\\' && (char)source.Peek() == '{')
-					{
-						source.Read();
-						if ((char)source.Peek() == '{')
-						{
-							source.Read();
-							buffer.Append('{', 2);
-						}
-						else
-						{
-							buffer.Append("\\{");
-						}
-						node = source.Read();
-					}
-					else if ((char)node == '{' && (char)source.Peek() == '{')
-					{
-						bool escaped = true;
-						bool raw = false;
-						trimWhitespace = false;
-						node = source.Read();
-						if ((char)source.Peek() == '{')
-						{
-							node = source.Read();
-							escaped = false;
-						}
-						if ((char)source.Peek() == '{')
-						{
-							node = source.Read();
-							raw = true;
-						}
-						if ((char)source.Peek() == '~')
-						{
-							source.Read();
-							node = source.Peek();
-							trimWhitespace = true;
-						}
-						yield return Token.Static(buffer.ToString());
-						yield return Token.StartExpression(escaped, trimWhitespace, raw);
-						trimWhitespace = false;
-						buffer = new StringBuilder();
-						inExpression = true;
-					}
-					else
-					{
-						buffer.Append((char)node);
-						node = source.Read();
-					}
-				}
-			}
-		}
-
-		private bool handleEscapeDepth(int node, TextReader source, StringBuilder buffer, bool hasDepth)
-		{
-			return false;
-		}
-	}
+                        if ((char)source.Peek() == '{')
+                            node = source.Read();
+                    }
+                    else if ((char)node == '\\' && (char)source.Peek() == '{')
+                    {
+                        source.Read();
+                        if ((char)source.Peek() == '{')
+                        {
+                            source.Read();
+                            buffer.Append('{', 2);
+                        }
+                        else
+                        {
+                            buffer.Append("\\{");
+                        }
+                        node = source.Read();
+                    }
+                    else if ((char)node == '{' && (char)source.Peek() == '{')
+                    {
+                        bool escaped = true;
+                        bool raw = false;
+                        trimWhitespace = false;
+                        node = source.Read();
+                        if ((char)source.Peek() == '{')
+                        {
+                            node = source.Read();
+                            escaped = false;
+                        }
+                        if ((char)source.Peek() == '{')
+                        {
+                            node = source.Read();
+                            raw = true;
+                        }
+                        if ((char)source.Peek() == '~')
+                        {
+                            source.Read();
+                            node = source.Peek();
+                            trimWhitespace = true;
+                        }
+                        yield return Token.Static(buffer.ToString());
+                        yield return Token.StartExpression(escaped, trimWhitespace, raw);
+                        trimWhitespace = false;
+                        buffer = new StringBuilder();
+                        inExpression = true;
+                    }
+                    else
+                    {
+                        buffer.Append((char)node);
+                        node = source.Read();
+                    }
+                }
+            }
+        }
+    }
 }
 

--- a/source/Handlebars/Handlebars.csproj
+++ b/source/Handlebars/Handlebars.csproj
@@ -6,7 +6,7 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Version>1.10.2</Version>
     <LangVersion>7</LangVersion>
-  </PropertyGroup>
+  </PropertyGroup> 
 
   <PropertyGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
     <DefineConstants>$(DefineConstants);netstandard</DefineConstants>

--- a/source/Handlebars/Handlebars.csproj
+++ b/source/Handlebars/Handlebars.csproj
@@ -3,14 +3,11 @@
   <PropertyGroup>
     <DebugType>portable</DebugType>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <TargetFrameworks>net452;netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Version>1.10.2</Version>
     <LangVersion>7</LangVersion>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)'=='netstandard1.3'">
-    <DefineConstants>$(DefineConstants);netstandard;netstandard1_3</DefineConstants>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
     <DefineConstants>$(DefineConstants);netstandard</DefineConstants>
   </PropertyGroup>
@@ -28,16 +25,13 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/rexm/Handlebars.Net</RepositoryUrl>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)'=='net452'">
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net452|AnyCPU'">
+    <DocumentationFile />
+  </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.3'">
-    <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
-    <PackageReference Include="System.Reflection.TypeExtensions " Version="4.3.0" />
-  </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
     <PackageReference Include="Microsoft.CSharp" Version="4.4.0" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.4.0" />


### PR DESCRIPTION
As i was testing some things we are trying to do with Handlebars.net in some json files and ran into an issue, when compiling a template with, the use of '\\'.  I added two unit tests, one to show Json serialization working without escape sequences, the other to demonstrate it broken.

The issue does not seem to happen against other escape sequences like \" as you'll see in the unit test.

